### PR TITLE
CAD-1962: rename release label to protocol.

### DIFF
--- a/src/Cardano/RTView/GUI/Grid.hs
+++ b/src/Cardano/RTView/GUI/Grid.hs
@@ -56,7 +56,7 @@ mkNodesGrid _window acceptors = do
 
 metricLabel :: ElementName -> String
 metricLabel ElTraceAcceptorEndpoint = "TraceAcceptor endpoint"
-metricLabel ElNodeRelease           = "Node release"
+metricLabel ElNodeRelease           = "Node protocol"
 metricLabel ElNodeVersion           = "Node version"
 metricLabel ElNodePlatform          = "Node platform"
 metricLabel ElNodeCommitHref        = "Node commit"

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -178,7 +178,7 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # showIt #+
          [ UI.div #. show W3Row #+
              [ UI.div #. show W3Third #+
-                 [ UI.div #+ [string "Node release:"]
+                 [ UI.div #+ [string "Node protocol:"]
                  , UI.div #+ [string "Node version:"]
                  , UI.div #+ [string "Node platform:"]
                  , UI.div #+ [string "Node commit:"]


### PR DESCRIPTION
To avoid confusing, rename `Node release` to `Node protocol` (because it's actually protocol).