### PR TITLE
CAD-1887: rename metric nodeCannotLead.

### DIFF
--- a/doc/gui-overview/grid-mode.md
+++ b/doc/gui-overview/grid-mode.md
@@ -21,7 +21,7 @@ At the top bar of the page, you will find the second dropdown list `Select metri
 ## Metrics
 
 * `TraceAcceptor endpoint` - network socket or the pipe used to connect this node with RTView;
-* `Node release` - node's release (for example, `Shelley`);
+* `Node protocol` - node's protocol (for example, `Shelley`);
 * `Node version` - version of the node;
 * `Node platform` - a platform the node is working on (for example, `Linux`);
 * `Node commit` - git commit the node was built from;
@@ -38,7 +38,7 @@ At the top bar of the page, you will find the second dropdown list `Select metri
 * `Slot in epoch` - the number of the current slot;
 * `Blocks number` - the number of blocks in this blockchain;
 * `Forged blocks number` - the number of blocks forged by this node;
-* `Cannot lead, number` - the number of slots when this node was a leader but because of misconfiguration (for example, invalid key), it's impossible to forge a new block;
+* `Cannot forge, number` - the number of slots when this node was a leader but because of misconfiguration (for example, invalid key), it's impossible to forge a new block;
 * `Chain density` - chain density, in percents;
 * `Slot leader, number` - the number of slots when this node was a leader;
 * `Missed slots number` - the number of slots when this node was a leader but didn't forge a new block;

--- a/doc/gui-overview/pane-mode.md
+++ b/doc/gui-overview/pane-mode.md
@@ -29,7 +29,7 @@ Each panel has the following tabs:
 
 This tab shows necessary information about the node:
 
-* `Node release` - node's release (for example, `Shelley`);
+* `Node protocol` - node's protocol (for example, `Shelley`);
 * `Node version` - version of the node;
 * `Node platform` - a platform the node is working on (for example, `Linux`);
 * `Node commit` - git commit the node was built from;
@@ -61,7 +61,7 @@ This tab displays blockchain-related information:
 * `Forged blocks number` - the number of blocks forged by this node;
 * `Chain density` - chain density, in percents;
 * `Slot leader, number` - the number of slots when this node was a leader;
-* `Cannot lead, number` - the number of slots when this node was a leader but because of misconfiguration (for example, invalid key), it's impossible to forge a new block;
+* `Cannot forge, number` - the number of slots when this node was a leader but because of misconfiguration (for example, invalid key), it's impossible to forge a new block;
 * `Missed slots number` - the number of slots when this node was a leader but didn't forge a new block.
 
 ### Mempool

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -50,7 +50,7 @@ data ElementName
   | ElSlot
   | ElBlocksNumber
   | ElBlocksForgedNumber
-  | ElNodeCannotLead
+  | ElNodeCannotForge
   | ElChainDensity
   | ElNodeIsLeaderNumber
   | ElSlotsMissedNumber

--- a/src/Cardano/RTView/GUI/Grid.hs
+++ b/src/Cardano/RTView/GUI/Grid.hs
@@ -74,7 +74,7 @@ metricLabel ElSlot                  = "Slot in epoch"
 metricLabel ElChainDensity          = "Chain density"
 metricLabel ElBlocksNumber          = "Blocks number"
 metricLabel ElBlocksForgedNumber    = "Forged blocks number"
-metricLabel ElNodeCannotLead        = "Cannot lead, number"
+metricLabel ElNodeCannotForge       = "Cannot forge, number"
 metricLabel ElNodeIsLeaderNumber    = "Slot leader, number"
 metricLabel ElSlotsMissedNumber     = "Missed slots number"
 metricLabel ElTxsProcessed          = "TXs processed"
@@ -106,7 +106,7 @@ allMetricsNames =
   , ElSlot
   , ElBlocksNumber
   , ElBlocksForgedNumber
-  , ElNodeCannotLead
+  , ElNodeCannotForge
   , ElChainDensity
   , ElNodeIsLeaderNumber
   , ElSlotsMissedNumber
@@ -187,7 +187,7 @@ mkNodeElements nameOfNode = do
   elSlot               <- string "0"
   elBlocksNumber       <- string "0"
   elBlocksForgedNumber <- string "0"
-  elNodeCannotLead     <- string "0"
+  elNodeCannotForge    <- string "0"
   elChainDensity       <- string "0"
   elNodeIsLeaderNumber <- string "0"
   elSlotsMissedNumber  <- string "0"
@@ -219,7 +219,7 @@ mkNodeElements nameOfNode = do
       , (ElSlot,                  elSlot)
       , (ElBlocksNumber,          elBlocksNumber)
       , (ElBlocksForgedNumber,    elBlocksForgedNumber)
-      , (ElNodeCannotLead,        elNodeCannotLead)
+      , (ElNodeCannotForge,       elNodeCannotForge)
       , (ElChainDensity,          elChainDensity)
       , (ElNodeIsLeaderNumber,    elNodeIsLeaderNumber)
       , (ElSlotsMissedNumber,     elSlotsMissedNumber)

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -36,7 +36,7 @@ mkNodePane nameOfNode = do
   elSlot                    <- string "0"
   elBlocksNumber            <- string "0"
   elBlocksForgedNumber      <- string "0"
-  elNodeCannotLead          <- string "0"
+  elNodeCannotForge         <- string "0"
   elChainDensity            <- string "0"
   elNodeIsLeaderNumber      <- string "0"
   elSlotsMissedNumber       <- string "0"
@@ -302,7 +302,7 @@ mkNodePane nameOfNode = do
                  , UI.div #+ [string "Forged blocks number:"]
                  , UI.div #+ [string "Chain density:"]
                  , UI.div #+ [string "Slot leader, number:"]
-                 , UI.div #+ [string "Cannot lead, number:"]
+                 , UI.div #+ [string "Cannot forge, number:"]
                  , UI.div #+ [string "Missed slots number:"]
                  ]
              , UI.div #. show W3Third #+
@@ -319,7 +319,7 @@ mkNodePane nameOfNode = do
                          , UI.span #. show DensityPercent #+ [string "%"]
                          ]
                      , UI.div #+ [element elNodeIsLeaderNumber]
-                     , UI.div #+ [element elNodeCannotLead]
+                     , UI.div #+ [element elNodeCannotForge]
                      , UI.div #+ [element elSlotsMissedNumber]
                      ]
                  ]
@@ -607,7 +607,7 @@ mkNodePane nameOfNode = do
           , (ElSlot,                    elSlot)
           , (ElBlocksNumber,            elBlocksNumber)
           , (ElBlocksForgedNumber,      elBlocksForgedNumber)
-          , (ElNodeCannotLead,          elNodeCannotLead)
+          , (ElNodeCannotForge,         elNodeCannotForge)
           , (ElChainDensity,            elChainDensity)
           , (ElNodeIsLeaderNumber,      elNodeIsLeaderNumber)
           , (ElSlotsMissedNumber,       elSlotsMissedNumber)

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -80,7 +80,7 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
     void $ updateElementValue (ElementInteger $ niSlot ni)                    $ elements ! ElSlot
     void $ updateElementValue (ElementInteger $ niBlocksNumber ni)            $ elements ! ElBlocksNumber
     void $ updateElementValue (ElementInteger $ niBlocksForgedNumber ni)      $ elements ! ElBlocksForgedNumber
-    void $ updateElementValue (ElementInteger $ niNodeCannotLead ni)          $ elements ! ElNodeCannotLead
+    void $ updateElementValue (ElementInteger $ niNodeCannotForge ni)         $ elements ! ElNodeCannotForge
     void $ updateElementValue (ElementDouble  $ niChainDensity ni)            $ elements ! ElChainDensity
     void $ updateElementValue (ElementInteger $ niNodeIsLeaderNum ni)         $ elements ! ElNodeIsLeaderNumber
     void $ updateElementValue (ElementInteger $ niSlotsMissedNumber ni)       $ elements ! ElSlotsMissedNumber
@@ -161,7 +161,7 @@ updateGridGUI window nodesState _params acceptors gridNodesStateElems =
     void $ updateElementValue (ElementInteger $ niSlot ni)               $ elements ! ElSlot
     void $ updateElementValue (ElementInteger $ niBlocksNumber ni)       $ elements ! ElBlocksNumber
     void $ updateElementValue (ElementInteger $ niBlocksForgedNumber ni) $ elements ! ElBlocksForgedNumber
-    void $ updateElementValue (ElementInteger $ niNodeCannotLead ni)     $ elements ! ElNodeCannotLead
+    void $ updateElementValue (ElementInteger $ niNodeCannotForge ni)    $ elements ! ElNodeCannotForge
     void $ updateElementValue (ElementDouble  $ niChainDensity ni)       $ elements ! ElChainDensity
     void $ updateElementValue (ElementInteger $ niNodeIsLeaderNum ni)    $ elements ! ElNodeIsLeaderNumber
     void $ updateElementValue (ElementInteger $ niSlotsMissedNumber ni)  $ elements ! ElSlotsMissedNumber
@@ -346,7 +346,7 @@ markOutdatedElements params ni nm els = do
   markValueW now (niBlocksNumberLastUpdate ni) bcLife [els ! ElBlocksNumber]
                                                       [els ! ElBlocksNumberOutdateWarning]
   markValueW now (niBlocksForgedNumberLastUpdate ni) bcLife [ els ! ElBlocksForgedNumber
-                                                            , els ! ElNodeCannotLead
+                                                            , els ! ElNodeCannotForge
                                                             ]
                                                             [els ! ElBlocksForgedNumberOutdateWarning]
   markValueW now (niChainDensityLastUpdate ni) bcLife [els ! ElChainDensity]

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -78,7 +78,7 @@ data NodeInfo
       , niBlocksNumberLastUpdate         :: !Word64
       , niBlocksForgedNumber             :: !Integer
       , niBlocksForgedNumberLastUpdate   :: !Word64
-      , niNodeCannotLead                 :: !Integer
+      , niNodeCannotForge                :: !Integer
       , niChainDensity                   :: !Double
       , niChainDensityLastUpdate         :: !Word64
       , niTxsProcessed                   :: !Integer
@@ -197,7 +197,7 @@ defaultNodeInfo = NodeInfo
   , niBlocksNumberLastUpdate        = 0
   , niBlocksForgedNumber            = 0
   , niBlocksForgedNumberLastUpdate  = 0
-  , niNodeCannotLead                = 0
+  , niNodeCannotForge               = 0
   , niChainDensity                  = 0.0
   , niChainDensityLastUpdate        = 0
   , niTxsProcessed                  = 0

--- a/src/Cardano/RTView/NodeState/Updater.hs
+++ b/src/Cardano/RTView/NodeState/Updater.hs
@@ -158,8 +158,8 @@ updateNodesState nsMVar loggerName (LogObject aName aMeta aContent) = do
                 nodesStateWith $ updateTxsProcessed ns processedTxsNum
               LogValue "blocksForgedNum" (PureI forgedBlocksNum) ->
                 nodesStateWith $ updateBlocksForged ns forgedBlocksNum now
-              LogValue "nodeCannotLead" (PureI cannotLead) ->
-                nodesStateWith $ updateNodeCannotLead ns cannotLead
+              LogValue "nodeCannotForge" (PureI cannotForge) ->
+                nodesStateWith $ updateNodeCannotForge ns cannotForge
               LogValue "nodeIsLeaderNum" (PureI leaderNum) ->
                 nodesStateWith $ updateNodeIsLeader ns leaderNum now
               LogValue "slotsMissedNum" (PureI missedSlotsNum) ->
@@ -526,12 +526,12 @@ updateBlocksForged ns blocksForged now = ns { nsInfo = newNi }
       }
   currentNi = nsInfo ns
 
-updateNodeCannotLead :: NodeState -> Integer -> NodeState
-updateNodeCannotLead ns cannotLead = ns { nsInfo = newNi }
+updateNodeCannotForge :: NodeState -> Integer -> NodeState
+updateNodeCannotForge ns cannotForge = ns { nsInfo = newNi }
  where
   newNi =
     currentNi
-      { niNodeCannotLead = cannotLead
+      { niNodeCannotForge = cannotForge
       }
   currentNi = nsInfo ns
 


### PR DESCRIPTION
The metric `nodeCannotLead` was renamed in `nodeCannotForge` (it's more technically correct) in the node, so now it's renamed in RTView as well.