### PR TITLE
CAD-1963: fix Peers number label.

### DIFF
--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -142,7 +142,8 @@ data ElementName
   deriving (Eq, Generic, NFData, Ord, Show)
 
 data ElementValue
-  = ElementInteger !Integer
+  = ElementInt     !Int
+  | ElementInteger !Integer
   | ElementWord64  !Word64
   | ElementDouble  !Double
   | ElementString  !String

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -41,7 +41,6 @@ mkNodePane nameOfNode = do
   elNodeIsLeaderNumber      <- string "0"
   elSlotsMissedNumber       <- string "0"
   elTxsProcessed            <- string "0"
-  elPeersNumber             <- string "0"
   elTraceAcceptorEndpoint   <- string "0"
   elOpCertStartKESPeriod    <- string "0"
   elCurrentKESPeriod        <- string "0"
@@ -612,7 +611,6 @@ mkNodePane nameOfNode = do
           , (ElNodeIsLeaderNumber,      elNodeIsLeaderNumber)
           , (ElSlotsMissedNumber,       elSlotsMissedNumber)
           , (ElTxsProcessed,            elTxsProcessed)
-          , (ElPeersNumber,             elPeersNumber)
           , (ElTraceAcceptorEndpoint,   elTraceAcceptorEndpoint)
           , (ElOpCertStartKESPeriod,    elOpCertStartKESPeriod)
           , (ElCurrentKESPeriod,        elCurrentKESPeriod)

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -85,7 +85,6 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
     void $ updateElementValue (ElementInteger $ niNodeIsLeaderNum ni)         $ elements ! ElNodeIsLeaderNumber
     void $ updateElementValue (ElementInteger $ niSlotsMissedNumber ni)       $ elements ! ElSlotsMissedNumber
     void $ updateElementValue (ElementInteger $ niTxsProcessed ni)            $ elements ! ElTxsProcessed
-    void $ updateElementValue (ElementInteger $ niPeersNumber ni)             $ elements ! ElPeersNumber
     void $ updateErrorsList   (niNodeErrors ni)                               $ elements ! ElNodeErrors
     void $ updateElementValue (ElementWord64  $ nmMempoolTxsNumber nm)        $ elements ! ElMempoolTxsNumber
     void $ updateElementValue (ElementDouble  $ nmMempoolTxsPercent nm)       $ elements ! ElMempoolTxsPercent
@@ -155,7 +154,7 @@ updateGridGUI window nodesState _params acceptors gridNodesStateElems =
     void $ updateElementValue (ElementString  $ niNodeVersion ni)        $ elements ! ElNodeVersion
     void $ updateElementValue (ElementString  $ niNodePlatform ni)       $ elements ! ElNodePlatform
     void $ updateNodeCommit   (niNodeCommit ni) (niNodeShortCommit ni)   $ elements ! ElNodeCommitHref
-    void $ updateElementValue (ElementInteger $ niPeersNumber ni)        $ elements ! ElPeersNumber
+    void $ updateElementValue (ElementInt     $ length (niPeersInfo ni)) $ elements ! ElPeersNumber
     void $ updateNodeUpTime   (niUpTime ni)                              $ elements ! ElUptime
     void $ updateElementValue (ElementInteger $ niEpoch ni)              $ elements ! ElEpoch
     void $ updateElementValue (ElementInteger $ niSlot ni)               $ elements ! ElSlot
@@ -182,6 +181,7 @@ updateElementValue
   :: ElementValue
   -> Element
   -> UI Element
+updateElementValue (ElementInt     i) el = element el # set text (show i)
 updateElementValue (ElementInteger i) el = element el # set text (show i)
 updateElementValue (ElementWord64  w) el = element el # set text (show w)
 updateElementValue (ElementDouble  d) el = element el # set text (showWith1DecPlace d)

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -82,7 +82,6 @@ data NodeInfo
       , niChainDensity                   :: !Double
       , niChainDensityLastUpdate         :: !Word64
       , niTxsProcessed                   :: !Integer
-      , niPeersNumber                    :: !Integer
       , niPeersInfo                      :: ![PeerInfo]
       , niTraceAcceptorHost              :: !String
       , niTraceAcceptorPort              :: !String
@@ -201,7 +200,6 @@ defaultNodeInfo = NodeInfo
   , niChainDensity                  = 0.0
   , niChainDensityLastUpdate        = 0
   , niTxsProcessed                  = 0
-  , niPeersNumber                   = 0
   , niPeersInfo                     = []
   , niTraceAcceptorHost             = "-"
   , niTraceAcceptorPort             = "-"

--- a/src/Cardano/RTView/NodeState/Updater.hs
+++ b/src/Cardano/RTView/NodeState/Updater.hs
@@ -195,11 +195,6 @@ updateNodesState nsMVar loggerName (LogObject aName aMeta aContent) = do
               LogValue "remainingKESPeriods" (PureI kesPeriodsUntilExpiry) ->
                 nodesStateWith $ updateRemainingKESPeriods ns kesPeriodsUntilExpiry now
               _ -> return currentNodesState
-           | "cardano.node.BlockFetchDecision" `T.isInfixOf` aName ->
-            case aContent of
-              LogValue "connectedPeers" (PureI peersNum) ->
-                nodesStateWith $ updatePeersNumber ns peersNum
-              _ -> return currentNodesState
            | "cardano.node.release" `T.isInfixOf` aName ->
             case aContent of
               LogMessage release ->
@@ -651,11 +646,6 @@ updateChainDensity ns density now = ns { nsInfo = newNi }
                       , niChainDensityLastUpdate = now
                       }
   chainDensity = 0.05 + density * 100.0
-
-updatePeersNumber :: NodeState -> Integer -> NodeState
-updatePeersNumber ns peersNum = ns { nsInfo = newNi }
- where
-  newNi = (nsInfo ns) { niPeersNumber = peersNum }
 
 updateBlocksNumber :: NodeState -> Integer -> Word64 -> NodeState
 updateBlocksNumber ns blockNum now = ns { nsInfo = newNi }


### PR DESCRIPTION
Now `Peers number` label (in Grid mode) takes its value from peers list, not from a separate metric (because it's not always up-to-date).