### PR TITLE
CAD-1967: fix Select metric list.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -233,6 +233,9 @@ ownCSS = unpack . TL.toStrict . render $ do
   cl SelectMetricCheck ? do
     marginRightPx     10
 
+  cl MetricsArea ? do
+    minWidthPx        300
+
   cl ProgressBar ?            progressBarColors greenDark  white
   cl ProgressBarOutdated ?    progressBarColors gray60     gray60
   cl ProgressBarBox ?         progressBarColors greenLight white
@@ -263,6 +266,7 @@ ownCSS = unpack . TL.toStrict . render $ do
   minHeightPx     = minHeight . px
   maxHeightPx     = maxHeight . px
 
+  minWidthPx      = minWidth . px
   maxWidthPx      = maxWidth . px
 
   progressBarColors bg c = do

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -185,6 +185,7 @@ data HTMLClass
   | InfoMark
   | InfoMarkImg
   | IOHKLogo
+  | MetricsArea
   | NodeContainer
   | NodeBar
   | NodeInfoValues

--- a/src/Cardano/RTView/GUI/Markup.hs
+++ b/src/Cardano/RTView/GUI/Markup.hs
@@ -159,7 +159,7 @@ topNavigation nodesSelector viewModeSelector metricsSelector =
         ]
     , UI.div ## show SelectMetricButton #. show W3DropdownHover # hideIt #+
         [ UI.button #. show W3Button #+ [string "Select metric ▾"]
-        , UI.div #. [W3DropdownContent, W3BarBlock, W3Card4] <+> [] #+ metricsSelector
+        , UI.div #. [W3DropdownContent, W3BarBlock, W3Card4] <+> [MetricsArea] #+ metricsSelector
         ]
     , UI.span #. [W3Right] <+> [ServiceName] #+
         [ string "Cardano Node Real-time View"


### PR DESCRIPTION
When you hover over Select metric, the very first item TraceAcceptor endpoint is displayed in two lines then after few seconds its moving to one line, changing the width of list and positions of elements, I mean user maybe pointing on some particular element on the list and when the click will happen list might slightly change at that time and different element will be clicked.