### PR TITLE
CAD-1998: Remove Resources progress bars.

### DIFF
--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -100,18 +100,6 @@ data ElementName
   | ElMempoolBytesProgressBox
   | ElMempoolTxsProgress
   | ElMempoolTxsProgressBox
-  | ElMemoryProgress
-  | ElMemoryProgressBox
-  | ElCPUProgress
-  | ElCPUProgressBox
-  | ElDiskReadProgress
-  | ElDiskReadProgressBox
-  | ElDiskWriteProgress
-  | ElDiskWriteProgressBox
-  | ElNetworkInProgress
-  | ElNetworkInProgressBox
-  | ElNetworkOutProgress
-  | ElNetworkOutProgressBox
   | ElRTSMemoryProgress
   | ElRTSMemoryProgressBox
   -- Charts

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -91,52 +91,6 @@ mkNodePane nameOfNode = do
                                  ]
   elMempoolTxsProgressBox   <- UI.div #. show ProgressBarBox #+ [element elMempoolTxsProgress]
 
-  elMemoryProgress          <- UI.div #. show ProgressBar #+
-                                 [ UI.span #. show HSpacer #+ []
-                                 , element elMemory
-                                 , UI.span #. show BarValueUnit #+ [string "MB"]
-                                 , UI.span #. show PercentsSlashHSpacer #+ [string "/"]
-                                 , UI.span #. show PercentsSlashHRSpacer #+ [string "max"]
-                                 , element elMemoryMax
-                                 , UI.span #. show BarValueUnit #+ [string "MB"]
-                                 ]
-  elMemoryProgressBox       <- UI.div #. show ProgressBarBox #+ [element elMemoryProgress]
-
-  elCPUProgress             <- UI.div #. show ProgressBar #+
-                                 [ UI.span #. show HSpacer #+ []
-                                 , element elCPUPercent
-                                 , string "%"
-                                 ]
-  elCPUProgressBox          <- UI.div #. show ProgressBarBox #+ [element elCPUProgress]
-
-  elDiskUsageRProgress      <- UI.div #. show ProgressBar #+
-                                 [ UI.span #. show HSpacer #+ []
-                                 , element elDiskUsageR
-                                 , UI.span #. show BarValueUnit #+ [string "KB/s"]
-                                 ]
-  elDiskUsageRProgressBox   <- UI.div #. show ProgressBarBox #+ [element elDiskUsageRProgress]
-
-  elDiskUsageWProgress      <- UI.div #. show ProgressBar #+
-                                 [ UI.span #. show HSpacer #+ []
-                                 , element elDiskUsageW
-                                 , UI.span #. show BarValueUnit #+ [string "KB/s"]
-                                 ]
-  elDiskUsageWProgressBox   <- UI.div #. show ProgressBarBox #+ [element elDiskUsageWProgress]
-
-  elNetworkUsageInProgress     <- UI.div #. show ProgressBar #+
-                                    [ UI.span #. show HSpacer #+ []
-                                    , element elNetworkUsageIn
-                                    , UI.span #. show BarValueUnit #+ [string "KB/s"]
-                                    ]
-  elNetworkUsageInProgressBox  <- UI.div #. show ProgressBarBox #+ [element elNetworkUsageInProgress]
-
-  elNetworkUsageOutProgress    <- UI.div #. show ProgressBar #+
-                                    [ UI.span #. show HSpacer #+ []
-                                    , element elNetworkUsageOut
-                                    , UI.span #. show BarValueUnit #+ [string "KB/s"]
-                                    ]
-  elNetworkUsageOutProgressBox <- UI.div #. show ProgressBarBox #+ [element elNetworkUsageOutProgress]
-
   elRTSMemoryProgress       <- UI.div #. show ProgressBar #+
                                  [ UI.span #. show HSpacer #+ []
                                  , element elRTSMemoryUsed
@@ -336,7 +290,7 @@ mkNodePane nameOfNode = do
          , vSpacer NodeMetricsVSpacer
          ]
 
-  resourcesTabContentCharts
+  resourcesTabContent
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Container #+
              [ UI.div #. show W3Row #+
@@ -365,80 +319,6 @@ mkNodePane nameOfNode = do
                  ]
              , vSpacer NodeMetricsVSpacer
              ]
-         ]
-
-  resourcesTabContentBars
-    <- UI.div #. show TabContainer # hideIt #+
-         [ UI.div #. show W3Row #+
-             [ UI.div #. show W3Container #+
-                 [ UI.div #. show W3Row #+
-                     [ UI.div #. show W3Half #+ [string "Memory usage"]
-                     , UI.div #. [W3Half, W3RightAlign] <+> [] #+
-                         [ element elMemoryMaxTotal
-                         , UI.span #. show ValueUnit #+ [string "MB"]
-                         ]
-                     ]
-                 , element elMemoryProgressBox
-                 ]
-             , vSpacer NodeMetricsVSpacer
-             , UI.div #. show W3Container #+
-                 [ UI.div #. show W3Row #+
-                     [ UI.div #. show W3Half #+ [string "CPU usage"]
-                     , UI.div #. [W3Half, W3RightAlign] <+> [] #+
-                         [ string "100"
-                         , UI.span #. show ValueUnitPercent #+ [string "%"]
-                         ]
-                     ]
-                 , element elCPUProgressBox
-                 ]
-             , vSpacer NodeMetricsVSpacer
-             , twoElementsInRow
-                (UI.div #. show W3Container #+
-                   [ UI.div #. show W3Row #+
-                       [ UI.div #. show W3Half #+ [string "Disk | RD"]
-                       , UI.div #. [W3Half, W3RightAlign] <+> [] #+
-                           [ element elDiskUsageRMaxTotal
-                           , UI.span #. show ValueUnit #+ [string "KB/s"]
-                           , infoMark "Maximum value over the last two minutes"
-                           ]
-                       ]
-                   , element elDiskUsageRProgressBox
-                   ])
-                (UI.div #. show W3Container #+
-                   [ UI.div #. show W3Row #+
-                       [ UI.div #. show W3Half #+ [string "Disk | WR"]
-                       , UI.div #. [W3Half, W3RightAlign] <+> [] #+
-                           [ element elDiskUsageWMaxTotal
-                           , UI.span #. show ValueUnit #+ [string "KB/s"]
-                           , infoMark "Maximum value over the last two minutes"
-                           ]
-                       ]
-                   , element elDiskUsageWProgressBox
-                   ])
-             , vSpacer NodeMetricsVSpacer
-             , twoElementsInRow
-                (UI.div #. show W3Container #+
-                   [ UI.div #. show W3Row #+
-                       [ UI.div #. show W3Half #+ [string "Network | IN"]
-                       , UI.div #. [W3Half, W3RightAlign] <+> [] #+
-                           [ element elNetworkUsageInMaxTotal
-                           , UI.span #. show ValueUnit #+ [string "KB/s"]
-                           ]
-                       ]
-                   , element elNetworkUsageInProgressBox
-                   ])
-                (UI.div #. show W3Container #+
-                   [ UI.div #. show W3Row #+
-                       [ UI.div #. show W3Half #+ [string "Network | OUT"]
-                       , UI.div #. [W3Half, W3RightAlign] <+> [] #+
-                           [ element elNetworkUsageOutMaxTotal
-                           , UI.span #. show ValueUnit #+ [string "KB/s"]
-                           ]
-                       ]
-                   , element elNetworkUsageOutProgressBox
-                   ])
-             ]
-         , vSpacer NodeMetricsVSpacer
          ]
 
   ghcRTSTabContent
@@ -522,29 +402,10 @@ mkNodePane nameOfNode = do
                              #+
                      [ UI.img #. show NodeMenuIcon # set UI.src "/static/images/mempool.svg"
                      ]
-  barsViewTab   <- UI.anchor #. [W3BarItem, W3Button, W3Mobile] <+> []
-                             # set UI.href "#"
-                             # set UI.title__ "Bars view"
+  resourcesTab  <- UI.button #. [W3BarItem, W3Button, W3Mobile] <+> []
+                             # set UI.title__ "Resources"
                              #+
-                     [ UI.img #. show NodeMenuIcon # set UI.src "/static/images/bars.svg"
-                     ]
-  chartsViewTab <- UI.anchor #. [W3BarItem, W3Button, W3Mobile] <+> []
-                             # set UI.href "#"
-                             # set UI.title__ "Charts view"
-                             #+
-                     [ UI.img #. show NodeMenuIcon # set UI.src "/static/images/charts.svg"
-                     ]
-  resourcesTab  <- UI.div #. [W3DropdownHover, W3Mobile] <+> [] #+
-                     [ UI.button #. show W3Button
-                                 # set UI.title__ "Resources"
-                                 #+
-                         [ UI.img #. show NodeMenuIcon # set UI.src "/static/images/resources.svg"
-                         , string " ▾"
-                         ]
-                     , UI.div #. [W3DropdownContent, W3BarBlock, W3Card4] <+> [] #+
-                         [ element barsViewTab
-                         , element chartsViewTab
-                         ]
+                     [ UI.img #. show NodeMenuIcon # set UI.src "/static/images/resources.svg"
                      ]
   ghcRTSTab     <- UI.button #. [W3BarItem, W3Button, W3Mobile] <+> []
                              # set UI.title__ "RTS GC"
@@ -557,18 +418,18 @@ mkNodePane nameOfNode = do
                      [ UI.img #. show NodeMenuIcon # set UI.src "/static/images/bugs.svg"
                      ]
 
-  let tabs :: [(Element, Element, Int)]
+  let tabs :: [((Element, Element), Int)]
       tabs =
-        [ (nodeTab,       nodeTabContent,            1)
-        , (kesTab,        kesTabContent,             2)
-        , (peersTab,      peersTabContent,           3)
-        , (blockchainTab, blockchainTabContent,      4)
-        , (mempoolTab,    mempoolTabContent,         5)
-        , (barsViewTab,   resourcesTabContentBars,   6)
-        , (chartsViewTab, resourcesTabContentCharts, 7)
-        , (errorsTab,     errorsTabContent,          8)
-        , (ghcRTSTab,     ghcRTSTabContent,          9)
-        ]
+        let allTabs = [ (nodeTab,       nodeTabContent)
+                      , (kesTab,        kesTabContent)
+                      , (peersTab,      peersTabContent)
+                      , (blockchainTab, blockchainTabContent)
+                      , (mempoolTab,    mempoolTabContent)
+                      , (resourcesTab,  resourcesTabContent)
+                      , (errorsTab,     errorsTabContent)
+                      , (ghcRTSTab,     ghcRTSTabContent)
+                      ]
+        in zip allTabs [1..length allTabs]
 
   registerClicksOnTabs tabs
 
@@ -594,8 +455,7 @@ mkNodePane nameOfNode = do
       , element peersTabContent
       , element blockchainTabContent
       , element mempoolTabContent
-      , element resourcesTabContentBars
-      , element resourcesTabContentCharts
+      , element resourcesTabContent
       , element errorsTabContent
       , element ghcRTSTabContent
       ]
@@ -654,18 +514,6 @@ mkNodePane nameOfNode = do
           , (ElMempoolBytesProgressBox, elMempoolBytesProgressBox)
           , (ElMempoolTxsProgress,      elMempoolTxsProgress)
           , (ElMempoolTxsProgressBox,   elMempoolTxsProgressBox)
-          , (ElMemoryProgress,          elMemoryProgress)
-          , (ElMemoryProgressBox,       elMemoryProgressBox)
-          , (ElCPUProgress,             elCPUProgress)
-          , (ElCPUProgressBox,          elCPUProgressBox)
-          , (ElDiskReadProgress,        elDiskUsageRProgress)
-          , (ElDiskReadProgressBox,     elDiskUsageRProgressBox)
-          , (ElDiskWriteProgress,       elDiskUsageWProgress)
-          , (ElDiskWriteProgressBox,    elDiskUsageWProgressBox)
-          , (ElNetworkInProgress,       elNetworkUsageInProgress)
-          , (ElNetworkInProgressBox,    elNetworkUsageInProgressBox)
-          , (ElNetworkOutProgress,      elNetworkUsageOutProgress)
-          , (ElNetworkOutProgressBox,   elNetworkUsageOutProgressBox)
           , (ElRTSMemoryProgress,       elRTSMemoryProgress)
           , (ElRTSMemoryProgressBox,    elRTSMemoryProgressBox)
           ]
@@ -677,24 +525,17 @@ mkNodePane nameOfNode = do
 vSpacer :: HTMLClass -> UI Element
 vSpacer className = UI.div #. show className #+ []
 
-twoElementsInRow :: UI Element -> UI Element -> UI Element
-twoElementsInRow firstOne secondOne =
-  UI.div #. show W3Row #+
-    [ UI.div #. show W3Half #+ [firstOne]
-    , UI.div #. show W3Half #+ [secondOne]
-    ]
-
 -- | Since information and metrics are splitted to tabs,
 --   we have to make them clickable and show which one is active.
 registerClicksOnTabs
-  :: [(Element, Element, Int)]
+  :: [((Element, Element), Int)]
   -> UI ()
 registerClicksOnTabs tabs =
-  forM_ tabs $ \(tab, _, tabNum) ->
+  forM_ tabs $ \((tab, _), tabNum) ->
     void $ UI.onEvent (UI.click tab) $ \_ -> showTabAndMakeItActive tabNum
  where
   showTabAndMakeItActive num =
-    forM_ tabs $ \(tab', tabContent, tabNum') ->
+    forM_ tabs $ \((tab', tabContent), tabNum') ->
       if num == tabNum'
         then do
           void $ element tabContent # showIt

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -122,12 +122,6 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
 
     void $ updateProgressBar (nmMempoolBytesPercent nm)    $ elements ! ElMempoolBytesProgress
     void $ updateProgressBar (nmMempoolTxsPercent nm)      $ elements ! ElMempoolTxsProgress
-    void $ updateProgressBar (nmMemoryPercent nm)          $ elements ! ElMemoryProgress
-    void $ updateProgressBar (nmCPUPercent nm)             $ elements ! ElCPUProgress
-    void $ updateProgressBar (nmDiskUsageRPercent nm)      $ elements ! ElDiskReadProgress
-    void $ updateProgressBar (nmDiskUsageWPercent nm)      $ elements ! ElDiskWriteProgress
-    void $ updateProgressBar (nmNetworkUsageInPercent nm)  $ elements ! ElNetworkInProgress
-    void $ updateProgressBar (nmNetworkUsageOutPercent nm) $ elements ! ElNetworkOutProgress
     void $ updateProgressBar (nmRTSMemoryUsedPercent nm)   $ elements ! ElRTSMemoryProgress
 
     markOutdatedElements params ni nm elements
@@ -338,7 +332,6 @@ markOutdatedElements params ni nm els = do
   -- Different metrics have different lifetime.
   let niLife  = rtvNodeInfoLife params
       bcLife  = rtvBlockchainInfoLife params
-      resLife = rtvResourcesInfoLife params
       rtsLife = rtvRTSInfoLife params
 
   markValues now (niUpTimeLastUpdate ni) niLife [ els ! ElUptime
@@ -374,42 +367,6 @@ markOutdatedElements params ni nm els = do
                                                              , ElRTSMemoryUsed
                                                              , ElRTSMemoryUsedPercent
                                                              ]
-  markProgressBar now (nmMemoryLastUpdate nm) resLife els ( ElMemoryProgress
-                                                          , ElMemoryProgressBox
-                                                          )
-                                                          [ ElMemoryMaxTotal
-                                                          , ElMemory
-                                                          , ElMemoryMax
-                                                          ]
-  markProgressBar now (nmCPULastUpdate nm)    resLife els ( ElCPUProgress
-                                                          , ElCPUProgressBox
-                                                          )
-                                                          [ ElCPUPercent
-                                                          ]
-  markProgressBar now (nmDiskUsageRLastUpdate nm) resLife els ( ElDiskReadProgress
-                                                              , ElDiskReadProgressBox
-                                                              )
-                                                              [ ElDiskUsageR
-                                                              , ElDiskUsageRMaxTotal
-                                                              ]
-  markProgressBar now (nmDiskUsageWLastUpdate nm) resLife els ( ElDiskWriteProgress
-                                                              , ElDiskWriteProgressBox
-                                                              )
-                                                              [ ElDiskUsageW
-                                                              , ElDiskUsageWMaxTotal
-                                                              ]
-  markProgressBar now (nmNetworkUsageInLastUpdate nm)  resLife els ( ElNetworkInProgress
-                                                                   , ElNetworkInProgressBox
-                                                                   )
-                                                                   [ ElNetworkUsageIn
-                                                                   , ElNetworkUsageInMaxTotal
-                                                                   ]
-  markProgressBar now (nmNetworkUsageOutLastUpdate nm) resLife els ( ElNetworkOutProgress
-                                                                   , ElNetworkOutProgressBox
-                                                                   )
-                                                                   [ ElNetworkUsageOut
-                                                                   , ElNetworkUsageOutMaxTotal
-                                                                   ]
 
 markValues
   :: Word64


### PR DESCRIPTION
Currently, we have two view modes for Resources (memory, CPU, disk, network) - progress bars and charts. They show the same metrics, but charts have one significant pro: they show the history, so the user can see what was the memory consumption, say, 30 minutes ago, which is impossible with progress bars.

Moreover, charts can use different designs and can be tuned dynamically (something like Grafana).

So, to make an interface simper, progress bars should be removed.