### PR TITLE
CAD-2025: improve Errors tab.

### DIFF
--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -63,6 +63,7 @@ data ElementName
   | ElCurrentKESPeriod
   | ElRemainingKESPeriods
   | ElNodeErrors
+  | ElNodeErrorsTab
   | ElMempoolTxsNumber
   | ElMempoolTxsPercent
   | ElMempoolBytes

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -494,6 +494,7 @@ mkNodePane nameOfNode = do
           , (ElCurrentKESPeriod,        elCurrentKESPeriod)
           , (ElRemainingKESPeriods,     elRemainingKESPeriods)
           , (ElNodeErrors,              elNodeErrorsList)
+          , (ElNodeErrorsTab,           errorsTab)
           , (ElMempoolTxsNumber,        elMempoolTxsNumber)
           , (ElMempoolTxsPercent,       elMempoolTxsPercent)
           , (ElMempoolBytes,            elMempoolBytes)

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -86,6 +86,7 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
     void $ updateElementValue (ElementInteger $ niSlotsMissedNumber ni)       $ elements ! ElSlotsMissedNumber
     void $ updateElementValue (ElementInteger $ niTxsProcessed ni)            $ elements ! ElTxsProcessed
     void $ updateErrorsList   (niNodeErrors ni)                               $ elements ! ElNodeErrors
+    void $ updateErrorsTab    (niNodeErrors ni)                               $ elements ! ElNodeErrorsTab
     void $ updateElementValue (ElementWord64  $ nmMempoolTxsNumber nm)        $ elements ! ElMempoolTxsNumber
     void $ updateElementValue (ElementDouble  $ nmMempoolTxsPercent nm)       $ elements ! ElMempoolTxsPercent
     void $ updateElementValue (ElementWord64  $ nmMempoolBytes nm)            $ elements ! ElMempoolBytes
@@ -306,6 +307,20 @@ updateErrorsList nodeErrors errorsList = do
       , UI.div #. [W3TwoThird, W3Theme] <+> [] #+ [UI.div #. className #+ [UI.string msg]]
       ]
   element errorsList # set children errors
+
+updateErrorsTab
+  :: [NodeError]
+  -> Element
+  -> UI Element
+updateErrorsTab nodeErrors errorsTab =
+  if null nodeErrors
+    then disableErrorsTab
+    else enableErrorsTab
+ where
+   disableErrorsTab = element errorsTab # set UI.enabled False
+                                        # set UI.title__ "Good news: there are no errors!"
+   enableErrorsTab  = element errorsTab # set UI.enabled True
+                                        # set UI.title__ "Errors"
 
 mkTraceAcceptorEndpoint
   :: Text


### PR DESCRIPTION
This was suggested:

```
It is not clear that inside the Errors tab we have a table with 2 columns and the name of the second column - Error message - could be interpreted as there is an Error in displaying the errors.

Idea - maybe we can make it look more like a table with an empty first raw? ...
```

This is a better idea:

```
if there's no error messages, the tab Errors will be disabled, and it's tooltip will display something like "there's no errors".
```