### PR TITLE
CAD-2026: tooltips for all metrics.

### DIFF
--- a/doc/gui-overview/grid-mode.md
+++ b/doc/gui-overview/grid-mode.md
@@ -18,36 +18,7 @@ At the top bar of the page, you will find the second dropdown list `Select metri
 1. Check the checkbox if you want to see the corresponding metric;
 2. Uncheck it if you're going to hide it.
 
-## Metrics
+## Tooltips
 
-* `TraceAcceptor endpoint` - network socket or the pipe used to connect this node with RTView;
-* `Node protocol` - node's protocol (for example, `Shelley`);
-* `Node version` - version of the node;
-* `Node platform` - a platform the node is working on (for example, `Linux`);
-* `Node commit` - git commit the node was built from;
-* `Peers number` - the number of connected peers;
-* `Node uptime` - how long the node is working;
-* `Start KES period` - certificate KES (Key Evolving Signature) start period;
-* `Current KES period` - current KES period;
-* `KES remaining periods` - KES periods until expiry;
-* `Memory usage` - how much memory is consumed by the node, in MB;
-* `CPU usage` - how many CPU is used by the node, in percents;
-* `Disk usage` - node's disk activity, **read/write**-operations, in KB/s;
-* `Network usage` - node's network activity, **input/output**-operations, in KB/s;
-* `Epoch` - the number of current epoch;
-* `Slot in epoch` - the number of the current slot;
-* `Blocks number` - the number of blocks in this blockchain;
-* `Forged blocks number` - the number of blocks forged by this node;
-* `Cannot forge, number` - the number of slots when this node was a leader but because of misconfiguration (for example, invalid key), it's impossible to forge a new block;
-* `Chain density` - chain density, in percents;
-* `Slot leader, number` - the number of slots when this node was a leader;
-* `Missed slots number` - the number of slots when this node was a leader but didn't forge a new block;
-* `TXs processed` - the number of processed transactions in this blockchain. These transactions are already removed from the mempool so that we can treat them as completely processed;
-* `TXs in mempool, number` - the number of transactions in the mempool;
-* `Txs in mempool, bytes` - the number of transactions in the mempool, in bytes;
-* `GC CPU time` - total CPU time used by the GC, in seconds;
-* `GC time elapsed` - total elapsed time used by the GC, in seconds;
-* `Number of GC runs` - total number of GCs;
-* `Major GC runs` - total number of major (oldest generation) GCs.
+As in Pane mode, the table in Grid mode contains metrics. For example, `Node protocol`, `Node version`, `Node endpoint`, etc. If you hover a mouse on the metric's name - in the left cell of each row - you will see a tooltip with short information about this metric.
 
-For more information about KES, please read ["Key Evolving Signature and KES period" article](https://docs.cardano.org/projects/cardano-node/en/latest/stake-pool-operations/KES_period.html).

--- a/src/Cardano/RTView/GUI/Grid.hs
+++ b/src/Cardano/RTView/GUI/Grid.hs
@@ -54,37 +54,37 @@ mkNodesGrid _window acceptors = do
 
   return (nodesGrid, nodesEls)
 
-metricLabel :: ElementName -> String
-metricLabel ElNodeProtocol          = "Node protocol"
-metricLabel ElNodeVersion           = "Node version"
-metricLabel ElNodePlatform          = "Node platform"
-metricLabel ElNodeCommitHref        = "Node commit"
-metricLabel ElUptime                = "Node uptime"
-metricLabel ElTraceAcceptorEndpoint = "Node endpoint"
-metricLabel ElPeersNumber           = "Peers number"
-metricLabel ElOpCertStartKESPeriod  = "Start KES period"
-metricLabel ElCurrentKESPeriod      = "Current KES period"
-metricLabel ElRemainingKESPeriods   = "KES remaining periods"
-metricLabel ElMemoryUsageChart      = "Memory usage"
-metricLabel ElCPUUsageChart         = "CPU usage"
-metricLabel ElDiskUsageChart        = "Disk usage"
-metricLabel ElNetworkUsageChart     = "Network usage"
-metricLabel ElEpoch                 = "Epoch"
-metricLabel ElSlot                  = "Slot in epoch"
-metricLabel ElChainDensity          = "Chain density"
-metricLabel ElBlocksNumber          = "Blocks number"
-metricLabel ElBlocksForgedNumber    = "Forged blocks number"
-metricLabel ElNodeCannotForge       = "Cannot forge, number"
-metricLabel ElNodeIsLeaderNumber    = "Slot leader, number"
-metricLabel ElSlotsMissedNumber     = "Missed slots number"
-metricLabel ElTxsProcessed          = "TXs processed"
-metricLabel ElMempoolTxsNumber      = "TXs in mempool, number"
-metricLabel ElMempoolBytes          = "Txs in mempool, bytes"
-metricLabel ElRTSGcCpu              = "GC CPU time"
-metricLabel ElRTSGcElapsed          = "GC time elapsed"
-metricLabel ElRTSGcNum              = "Number of GC runs"
-metricLabel ElRTSGcMajorNum         = "Major GC runs"
-metricLabel _                       = ""
+metricLabel :: ElementName -> (String, String)
+metricLabel ElNodeProtocol          = ("Node protocol", "Node's protocol")
+metricLabel ElNodeVersion           = ("Node version", "Version of the node")
+metricLabel ElNodePlatform          = ("Node platform", "Platform the node is working on")
+metricLabel ElNodeCommitHref        = ("Node commit", "Git commit the node was built from")
+metricLabel ElUptime                = ("Node uptime", "How long the node is working")
+metricLabel ElTraceAcceptorEndpoint = ("Node endpoint", "Socket/pipe used to connect the node with RTView")
+metricLabel ElPeersNumber           = ("Peers number", "Number of peers connected to the node")
+metricLabel ElOpCertStartKESPeriod  = ("Start KES period", "Certificate KES start period")
+metricLabel ElCurrentKESPeriod      = ("Current KES period", "Current KES period")
+metricLabel ElRemainingKESPeriods   = ("KES remaining periods", "KES periods until expiry")
+metricLabel ElMemoryUsageChart      = ("Memory usage", "Memory used by the node, in MB")
+metricLabel ElCPUUsageChart         = ("CPU usage", "CPU used by the node, in percents")
+metricLabel ElDiskUsageChart        = ("Disk usage", "Node's disk operations, both READ and WRITE")
+metricLabel ElNetworkUsageChart     = ("Network usage", "Node's network operations, both IN and OUT")
+metricLabel ElEpoch                 = ("Epoch", "Number of current epoch")
+metricLabel ElSlot                  = ("Slot in epoch", "Number of the current slot in this epoch")
+metricLabel ElChainDensity          = ("Chain density", "Chain density, in percents")
+metricLabel ElBlocksNumber          = ("Blocks number", "Total number of blocks in this blockchain")
+metricLabel ElBlocksForgedNumber    = ("Forged blocks number", "Number of blocks forged by this node")
+metricLabel ElNodeCannotForge       = ("Cannot forge, number", "Number of slots when this node was a leader but because of misconfiguration, it's impossible to forge a new block")
+metricLabel ElNodeIsLeaderNumber    = ("Slot leader, number", "Number of slots when this node was a leader")
+metricLabel ElSlotsMissedNumber     = ("Missed slots number", "Number of slots when this node was a leader but didn't forge a new block")
+metricLabel ElTxsProcessed          = ("TXs processed", "Number of processed transactions in this blockchain (these transactions are already removed from the mempool")
+metricLabel ElMempoolTxsNumber      = ("TXs in mempool, number", "Number of transactions in the mempool")
+metricLabel ElMempoolBytes          = ("Txs in mempool, bytes", "Size of all transactions in the mempool, in bytes")
+metricLabel ElRTSGcCpu              = ("GC CPU time", "Total CPU time used by the GC, in seconds")
+metricLabel ElRTSGcElapsed          = ("GC time elapsed", "Total elapsed time used by the GC, in seconds")
+metricLabel ElRTSGcNum              = ("Number of GC runs", "Total number of GCs")
+metricLabel ElRTSGcMajorNum         = ("Major GC runs", "Total number of major (oldest generation) GCs")
+metricLabel _                       = ("", "")
 
 allMetricsNames :: [ElementName]
 allMetricsNames =
@@ -138,7 +138,8 @@ mkRowCells
   -> ElementName
   -> UI [UI Element]
 mkRowCells nodesElements elemName = do
-  tagTd <- element <$> UI.td #+ [string $ metricLabel elemName]
+  tagTd <- element <$> UI.td #+ [string (fst $ metricLabel elemName)
+                                        # set UI.title__ (snd $ metricLabel elemName)]
   -- We specify HTML-id for each td because each td corresponds to "node column".
   -- It can be used to hide/show the whole column.
   tds <- forM nodesElements $ \(nameOfNode, nodeElements, _) ->

--- a/src/Cardano/RTView/GUI/Markup.hs
+++ b/src/Cardano/RTView/GUI/Markup.hs
@@ -281,7 +281,7 @@ mkCheckbox window elemName = do
   metricArea
     <- UI.div #. show SelectMetricCheckArea #+
          [ element metricCheckbox
-         , UI.label #+ [UI.string $ metricLabel elemName]
+         , UI.label #+ [UI.string $ fst $ metricLabel elemName]
          ]
   return metricArea
 

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -108,14 +108,14 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # showIt #+
          [ UI.div #. show W3Row #+
              [ UI.div #. show W3Half #+
-                 [ UI.div #+ [string "Node protocol"]
-                 , UI.div #+ [string "Node version"]
-                 , UI.div #+ [string "Node platform"]
-                 , UI.div #+ [string "Node commit"]
+                 [ UI.div #+ [string "Node protocol" # set UI.title__ "Node's protocol"]
+                 , UI.div #+ [string "Node version"  # set UI.title__ "Version of the node"]
+                 , UI.div #+ [string "Node platform" # set UI.title__ "Platform the node is working on"]
+                 , UI.div #+ [string "Node commit"   # set UI.title__ "Git commit the node was built from"]
                  , vSpacer NodeInfoVSpacer
-                 , UI.div #+ [string "Node uptime"]
+                 , UI.div #+ [string "Node uptime"   # set UI.title__ "How long the node is working"]
                  , vSpacer NodeInfoVSpacer
-                 , UI.div #+ [string "Node endpoint"]
+                 , UI.div #+ [string "Node endpoint" # set UI.title__ "Socket/pipe used to connect the node with RTView"]
                  , vSpacer NodeInfoVSpacer
                  ]
              , UI.div #. show W3Half #+
@@ -138,9 +138,9 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Row #+
              [ UI.div #. show W3Half #+
-                 [ UI.div #+ [string "Start KES period"]
-                 , UI.div #+ [string "KES period"]
-                 , UI.div #+ [string "KES remaining"]
+                 [ UI.div #+ [string "Start KES period" # set UI.title__ "Certificate KES start period"]
+                 , UI.div #+ [string "KES period"       # set UI.title__ "Current KES period"]
+                 , UI.div #+ [string "KES remaining"    # set UI.title__ "KES periods until expiry"]
                  , vSpacer NodeInfoVSpacer
                  ]
              , UI.div #. show W3Half #+
@@ -175,11 +175,11 @@ mkNodePane nameOfNode = do
                        , UI.div #. [W3Quarter, W3RightAlign] <+> [NodeMetricsValues] #+
                            [element slotNumber]
                        , UI.div #. [W3Quarter, W3RightAlign] <+> [NodeMetricsValues] #+
-                           [ element bytesInF
+                           [ element bytesInF # set UI.title__ "Sum of the byte count of blocks expected from all in-flight fetch requests"
                            , string " / "
-                           , element reqsInF
+                           , element reqsInF # set UI.title__ "Number of blocks fetch requests that are currently in-flight"
                            , string " / "
-                           , element blocksInF
+                           , element blocksInF # set UI.title__ "Blocks that are currently in-flight"
                            ]
                        , UI.div #. [W3Quarter, W3RightAlign] <+> [NodeMetricsValues] #+
                            [element status]
@@ -195,16 +195,16 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Row #+
              [ UI.div #. show W3Quarter #+
-                 [ string "Endpoint"
+                 [ string "Endpoint" # set UI.title__ "How the peer connected to this node"
                  ]
              , UI.div #. [W3Quarter, W3RightAlign] <+> [] #+
-                 [ string "Slot No."
+                 [ string "Slot No." # set UI.title__ "Total number of peers reported by peer"
                  ]
              , UI.div #. [W3Quarter, W3RightAlign] <+> [] #+
-                 [ string "In Flight: b/r/bl" # set UI.title__ "In Flight: bytes/reqs/blocks"
+                 [ string "In Flight: b/r/bl" # set UI.title__ "In Flight: bytes/requests/blocks"
                  ]
              , UI.div #. [W3Quarter, W3RightAlign] <+> [] #+
-                 [ string "Status"
+                 [ string "Status" # set UI.title__ "Peer's status"
                  ]
              ]
          , UI.div #+ elPeersList
@@ -214,15 +214,15 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Row #+
              [ UI.div #. show W3Half #+
-                 [ UI.div #+ [string "Epoch / Slot in epoch"]
-                 , UI.div #+ [string "Blocks number"]
-                 , UI.div #+ [string "Forged blocks number"]
+                 [ UI.div #+ [string "Epoch / Slot in epoch" # set UI.title__ "Number of current epoch / number of the current slot in this epoch"]
+                 , UI.div #+ [string "Blocks number" # set UI.title__ "Total number of blocks in this blockchain"]
+                 , UI.div #+ [string "Forged blocks number" # set UI.title__ "Number of blocks forged by this node"]
                  , vSpacer NodeInfoVSpacer
-                 , UI.div #+ [string "Chain density"]
+                 , UI.div #+ [string "Chain density" # set UI.title__ "Chain density, in percents"]
                  , vSpacer NodeInfoVSpacer
-                 , UI.div #+ [string "Slot leader, number"]
-                 , UI.div #+ [string "Cannot forge, number"]
-                 , UI.div #+ [string "Missed slots number"]
+                 , UI.div #+ [string "Slot leader, number" # set UI.title__ "Number of slots when this node was a leader"]
+                 , UI.div #+ [string "Cannot forge, number" # set UI.title__ "Number of slots when this node was a leader but because of misconfiguration, it's impossible to forge a new block"]
+                 , UI.div #+ [string "Missed slots number" # set UI.title__ "Number of slots when this node was a leader but didn't forge a new block"]
                  , vSpacer NodeInfoVSpacer
                  ]
              , UI.div #. show W3Half #+
@@ -258,7 +258,7 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Container #+
              [ UI.div #. show W3Row #+
-                 [ UI.div #. show W3Half #+ [string "Mempool | bytes"]
+                 [ UI.div #. show W3Half #+ [string "Mempool | bytes" # set UI.title__ "Size of all transactions in the mempool, in bytes"]
                  , UI.div #. [W3Half, W3RightAlign] <+> [] #+
                      [ element elMempoolMaxBytes
                      , infoMark "Maximum in bytes"
@@ -269,7 +269,7 @@ mkNodePane nameOfNode = do
          , vSpacer NodeMetricsVSpacer
          , UI.div #. show W3Container #+
              [ UI.div #. show W3Row #+
-                 [ UI.div #. show W3Half #+ [string "Mempool | TXs"]
+                 [ UI.div #. show W3Half #+ [string "Mempool | TXs" # set UI.title__ "Number of transactions in the mempool"]
                  , UI.div #. [W3Half, W3RightAlign] <+> [] #+
                      [ element elMempoolMaxTxs
                      , infoMark "Maximum in txs"
@@ -280,7 +280,7 @@ mkNodePane nameOfNode = do
          , vSpacer NodeMetricsVSpacer
          , UI.div #. show W3Row #+
               [ UI.div #. show W3Theme #+
-                  [ string "TXs processed"
+                  [ string "TXs processed" # set UI.title__ "Number of processed transactions in this blockchain (these transactions are already removed from the mempool)"
                   , nbsp
                   , nbsp
                   , nbsp
@@ -330,7 +330,7 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Container #+
              [ UI.div #. show W3Row #+
-                 [ UI.div #. show W3Half #+ [string "RTS live memory"]
+                 [ UI.div #. show W3Half #+ [string "RTS live memory" # set UI.title__ "Total amount of live data in the heap, in MB (updated after every GC)"]
                  , UI.div #. [W3Half, W3RightAlign] <+> [] #+
                      [ element elRTSMemoryAllocated
                      , UI.span #. show ValueUnit #+ [string "MB"]
@@ -341,10 +341,10 @@ mkNodePane nameOfNode = do
          , vSpacer NodeMetricsVSpacer
          , UI.div #. show W3Row #+
              [ UI.div #. show W3Half #+
-                 [ UI.div #+ [string "GC CPU time"]
-                 , UI.div #+ [string "GC time elapsed"]
-                 , UI.div #+ [string "Number of GC runs"]
-                 , UI.div #+ [string "Major GC runs"]
+                 [ UI.div #+ [string "GC CPU time"       # set UI.title__ "Total CPU time used by the GC, in seconds"]
+                 , UI.div #+ [string "GC time elapsed"   # set UI.title__ "Total elapsed time used by the GC, in seconds"]
+                 , UI.div #+ [string "Number of GC runs" # set UI.title__ "Total number of GCs"]
+                 , UI.div #+ [string "Major GC runs"     # set UI.title__ "Total number of major (oldest generation) GCs"]
                  ]
              , UI.div #. show W3Half #+
                  [ UI.div #. show NodeInfoValues #+


### PR DESCRIPTION
Since RTView provides web-page, it's possible to add tooltips for every displayed metric. In this case, the user can just hover a metric and see what is it all about, without going to documentation.