### PR TITLE
CAD-2030: Resources hover correct color.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -107,6 +107,9 @@ ownCSS = unpack . TL.toStrict . render $ do
   cl ActiveTab ? do
     important $
       backgroundColor "#1b2238"
+    important $
+      color           cardanoLight
+    fontWeight        bold
 
   cl TabContainer ? do
     paddingTopPx      16


### PR DESCRIPTION
1. Open Resources dropdown
2. Select 1 option
3. Move the mouse on top of other option --> the title of the selected option is not longer visible