### PR TITLE
CAD-2078: add KES remaining in days.

### DIFF
--- a/src/Cardano/RTView.hs
+++ b/src/Cardano/RTView.hs
@@ -54,7 +54,7 @@ runCardanoRTView params' = do
   --   2. node state updater (it gets metrics from |LogBuffer| and updates NodeState),
   --   3. server (it serves requests from user's browser and shows nodes' metrics in the real time).
   acceptorThr <- async $ launchMetricsAcceptor config accTr switchBoard
-  updaterThr  <- async $ launchNodeStateUpdater tr switchBoard be nodesStateMVar
+  updaterThr  <- async $ launchNodeStateUpdater tr params switchBoard be nodesStateMVar
   serverThr   <- async $ launchServer nodesStateMVar params acceptors
 
   void $ waitAnyCancel [acceptorThr, updaterThr, serverThr]

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -60,8 +60,10 @@ data ElementName
   | ElTraceAcceptorPort
   | ElTraceAcceptorEndpoint
   | ElOpCertStartKESPeriod
+  | ElOpCertExpiryKESPeriod
   | ElCurrentKESPeriod
   | ElRemainingKESPeriods
+  | ElRemainingKESPeriodsInDays
   | ElNodeErrors
   | ElNodeErrorsTab
   | ElMempoolTxsNumber

--- a/src/Cardano/RTView/GUI/Grid.hs
+++ b/src/Cardano/RTView/GUI/Grid.hs
@@ -61,8 +61,10 @@ metricLabel ElUptime                = ("Node uptime", "How long the node is work
 metricLabel ElTraceAcceptorEndpoint = ("Node endpoint", "Socket/pipe used to connect the node with RTView")
 metricLabel ElPeersNumber           = ("Peers number", "Number of peers connected to the node")
 metricLabel ElOpCertStartKESPeriod  = ("Start KES period", "Certificate KES start period")
+metricLabel ElOpCertExpiryKESPeriod = ("Expiry KES period", "Certificate KES expiry period")
 metricLabel ElCurrentKESPeriod      = ("Current KES period", "Current KES period")
 metricLabel ElRemainingKESPeriods   = ("KES remaining periods", "KES periods until expiry")
+metricLabel ElRemainingKESPeriodsInDays = ("KES remaining periods, days", "KES periods until expiry, in days")
 metricLabel ElMemoryUsageChart      = ("Memory usage", "Memory used by the node, in MB")
 metricLabel ElCPUUsageChart         = ("CPU usage", "CPU used by the node, in percents")
 metricLabel ElDiskUsageChart        = ("Disk usage", "Node's disk operations, both READ and WRITE")
@@ -94,8 +96,10 @@ allMetricsNames =
   , ElTraceAcceptorEndpoint
   , ElPeersNumber
   , ElOpCertStartKESPeriod
+  , ElOpCertExpiryKESPeriod
   , ElCurrentKESPeriod
   , ElRemainingKESPeriods
+  , ElRemainingKESPeriodsInDays
   , ElMemoryUsageChart
   , ElCPUUsageChart
   , ElDiskUsageChart
@@ -159,11 +163,13 @@ mkNodeElements nameOfNode = do
                  # set UI.title__ "Browse cardano-node repository on this commit"
                  #+ [string ""]
   elUptime      <- string "00:00:00"
-  elTraceAcceptorEndpoint <- string "localhost:0"
+  elTraceAcceptorEndpoint <- string "0.0.0.0:0"
   elPeersNumber <- string "0"
-  elOpCertStartKESPeriod <- string "-"
-  elCurrentKESPeriod     <- string "-"
-  elRemainingKESPeriods  <- string "-"
+  elOpCertStartKESPeriod      <- string "-"
+  elOpCertExpiryKESPeriod     <- string "-"
+  elCurrentKESPeriod          <- string "-"
+  elRemainingKESPeriods       <- string "-"
+  elRemainingKESPeriodsInDays <- string "-"
 
   elMemoryUsageChart
     <- UI.canvas ## (show GridMemoryUsageChartId <> T.unpack nameOfNode)
@@ -208,8 +214,10 @@ mkNodeElements nameOfNode = do
       , (ElTraceAcceptorEndpoint, elTraceAcceptorEndpoint)
       , (ElPeersNumber,           elPeersNumber)
       , (ElOpCertStartKESPeriod,  elOpCertStartKESPeriod)
+      , (ElOpCertExpiryKESPeriod, elOpCertExpiryKESPeriod)
       , (ElCurrentKESPeriod,      elCurrentKESPeriod)
       , (ElRemainingKESPeriods,   elRemainingKESPeriods)
+      , (ElRemainingKESPeriodsInDays, elRemainingKESPeriodsInDays)
       , (ElMemoryUsageChart,      elMemoryUsageChart)
       , (ElCPUUsageChart,         elCPUUsageChart)
       , (ElDiskUsageChart,        elDiskUsageChart)

--- a/src/Cardano/RTView/GUI/Pane.hs
+++ b/src/Cardano/RTView/GUI/Pane.hs
@@ -43,8 +43,10 @@ mkNodePane nameOfNode = do
   elTxsProcessed            <- string "0"
   elTraceAcceptorEndpoint   <- string "0"
   elOpCertStartKESPeriod    <- string "0"
+  elOpCertExpiryKESPeriod   <- string "0"
   elCurrentKESPeriod        <- string "0"
   elRemainingKESPeriods     <- string "0"
+  elRemainingKESPeriodsInDays <- string "0"
   elMempoolTxsNumber        <- string "0"
   elMempoolTxsPercent       <- string "0"
   elMempoolBytes            <- string "0"
@@ -138,16 +140,20 @@ mkNodePane nameOfNode = do
     <- UI.div #. show TabContainer # hideIt #+
          [ UI.div #. show W3Row #+
              [ UI.div #. show W3Half #+
-                 [ UI.div #+ [string "Start KES period" # set UI.title__ "Certificate KES start period"]
-                 , UI.div #+ [string "KES period"       # set UI.title__ "Current KES period"]
-                 , UI.div #+ [string "KES remaining"    # set UI.title__ "KES periods until expiry"]
+                 [ UI.div #+ [string "Start KES period"    # set UI.title__ "Certificate KES start period"]
+                 , UI.div #+ [string "Expiry KES period"   # set UI.title__ "Certificate KES expiry period"]
+                 , UI.div #+ [string "KES period"          # set UI.title__ "Current KES period"]
+                 , UI.div #+ [string "KES remaining"       # set UI.title__ "KES periods until expiry"]
+                 , UI.div #+ [string "KES remaining, days" # set UI.title__ "KES periods until expiry, in days"]
                  , vSpacer NodeInfoVSpacer
                  ]
              , UI.div #. show W3Half #+
                  [ UI.div #. show NodeInfoValues #+
                      [ UI.div #+ [element elOpCertStartKESPeriod]
+                     , UI.div #+ [element elOpCertExpiryKESPeriod]
                      , UI.div #+ [element elCurrentKESPeriod]
                      , UI.div #+ [element elRemainingKESPeriods]
+                     , UI.div #+ [element elRemainingKESPeriodsInDays]
                      , vSpacer NodeInfoVSpacer
                      ]
                  ]
@@ -491,8 +497,10 @@ mkNodePane nameOfNode = do
           , (ElTxsProcessed,            elTxsProcessed)
           , (ElTraceAcceptorEndpoint,   elTraceAcceptorEndpoint)
           , (ElOpCertStartKESPeriod,    elOpCertStartKESPeriod)
+          , (ElOpCertExpiryKESPeriod,   elOpCertExpiryKESPeriod)
           , (ElCurrentKESPeriod,        elCurrentKESPeriod)
           , (ElRemainingKESPeriods,     elRemainingKESPeriods)
+          , (ElRemainingKESPeriodsInDays, elRemainingKESPeriodsInDays)
           , (ElNodeErrors,              elNodeErrorsList)
           , (ElNodeErrorsTab,           errorsTab)
           , (ElMempoolTxsNumber,        elMempoolTxsNumber)

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -118,9 +118,11 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
     void $ updateElementValue (ElementInteger $ nmRTSGcNum nm)                $ elements ! ElRTSGcNum
     void $ updateElementValue (ElementInteger $ nmRTSGcMajorNum nm)           $ elements ! ElRTSGcMajorNum
 
-    updateKESInfo [ (niOpCertStartKESPeriod ni, elements ! ElOpCertStartKESPeriod)
-                  , (niCurrentKESPeriod ni,     elements ! ElCurrentKESPeriod)
-                  , (niRemainingKESPeriods ni,  elements ! ElRemainingKESPeriods)
+    updateKESInfo [ (niOpCertStartKESPeriod ni,      elements ! ElOpCertStartKESPeriod)
+                  , (niOpCertExpiryKESPeriod ni,     elements ! ElOpCertExpiryKESPeriod)
+                  , (niCurrentKESPeriod ni,          elements ! ElCurrentKESPeriod)
+                  , (niRemainingKESPeriods ni,       elements ! ElRemainingKESPeriods)
+                  , (niRemainingKESPeriodsInDays ni, elements ! ElRemainingKESPeriodsInDays)
                   ]
 
     updatePeersList (niPeersInfo ni) peerInfoItems
@@ -171,9 +173,11 @@ updateGridGUI window nodesState _params acceptors gridNodesStateElems =
     void $ updateElementValue (ElementInteger $ nmRTSGcNum nm)           $ elements ! ElRTSGcNum
     void $ updateElementValue (ElementInteger $ nmRTSGcMajorNum nm)      $ elements ! ElRTSGcMajorNum
 
-    updateKESInfo [ (niOpCertStartKESPeriod ni, elements ! ElOpCertStartKESPeriod)
-                  , (niCurrentKESPeriod ni,     elements ! ElCurrentKESPeriod)
-                  , (niRemainingKESPeriods ni,  elements ! ElRemainingKESPeriods)
+    updateKESInfo [ (niOpCertStartKESPeriod ni,      elements ! ElOpCertStartKESPeriod)
+                  , (niOpCertExpiryKESPeriod ni,     elements ! ElOpCertExpiryKESPeriod)
+                  , (niCurrentKESPeriod ni,          elements ! ElCurrentKESPeriod)
+                  , (niRemainingKESPeriods ni,       elements ! ElRemainingKESPeriods)
+                  , (niRemainingKESPeriodsInDays ni, elements ! ElRemainingKESPeriodsInDays)
                   ]
 
 updateElementValue
@@ -360,9 +364,12 @@ markOutdatedElements params ni nm els = do
                                                 , els ! ElNodeCommitHref
                                                 ]
   markValues now (niEpochLastUpdate ni) bcLife [els ! ElEpoch]
-  markValues now (niOpCertStartKESPeriodLastUpdate ni) niLife [els ! ElOpCertStartKESPeriod]
-  markValues now (niCurrentKESPeriodLastUpdate ni)     niLife [els ! ElCurrentKESPeriod]
-  markValues now (niRemainingKESPeriodsLastUpdate ni)  niLife [els ! ElRemainingKESPeriods]
+  markValues now (niOpCertStartKESPeriodLastUpdate ni)  niLife [els ! ElOpCertStartKESPeriod]
+  markValues now (niOpCertExpiryKESPeriodLastUpdate ni) niLife [els ! ElOpCertExpiryKESPeriod]
+  markValues now (niCurrentKESPeriodLastUpdate ni)      niLife [els ! ElCurrentKESPeriod]
+  markValues now (niRemainingKESPeriodsLastUpdate ni)   niLife [ els ! ElRemainingKESPeriods
+                                                               , els ! ElRemainingKESPeriodsInDays
+                                                               ]
 
   markValues now (niSlotLastUpdate ni)               bcLife [els ! ElSlot]
   markValues now (niBlocksNumberLastUpdate ni)       bcLife [els ! ElBlocksNumber]

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -88,9 +88,12 @@ data NodeInfo
       , niTraceAcceptorHost              :: !String
       , niTraceAcceptorPort              :: !String
       , niRemainingKESPeriods            :: !Integer
+      , niRemainingKESPeriodsInDays      :: !Integer
       , niRemainingKESPeriodsLastUpdate  :: !Word64
       , niOpCertStartKESPeriod           :: !Integer
       , niOpCertStartKESPeriodLastUpdate :: !Word64
+      , niOpCertExpiryKESPeriod           :: !Integer
+      , niOpCertExpiryKESPeriodLastUpdate :: !Word64
       , niCurrentKESPeriod               :: !Integer
       , niCurrentKESPeriodLastUpdate     :: !Word64
       , niNodeErrors                     :: ![NodeError]
@@ -206,9 +209,12 @@ defaultNodeInfo = NodeInfo
   , niTraceAcceptorHost             = "-"
   , niTraceAcceptorPort             = "-"
   , niRemainingKESPeriods           = 9999999999
+  , niRemainingKESPeriodsInDays     = 9999999999
   , niRemainingKESPeriodsLastUpdate = 0
   , niOpCertStartKESPeriod          = 9999999999
   , niOpCertStartKESPeriodLastUpdate = 0
+  , niOpCertExpiryKESPeriod          = 9999999999
+  , niOpCertExpiryKESPeriodLastUpdate = 0
   , niCurrentKESPeriod              = 9999999999
   , niCurrentKESPeriodLastUpdate    = 0
   , niNodeErrors                    = []


### PR DESCRIPTION
It would be nice to have another line inside the KES tab specifying in how many days the actual KES should be renewed. For mainnet, I think it is something like `cardano_node_Forge_metrics_remainingKESPeriods_int * 129600 * 1 / 3600 / 24`.