### PR TITLE
CAD-2068: move to GHC 8.10.2.

### DIFF
--- a/cardano-rt-view.cabal
+++ b/cardano-rt-view.cabal
@@ -41,7 +41,6 @@ library
                      , ansi-terminal
                      , async
                      , base >=4.12 && <5
-                     , bytestring
                      , clay
                      , containers
                      , deepseq
@@ -61,7 +60,7 @@ library
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
 
-  ghc-options:         -Weverything
+  ghc-options:         -Wall
                        -fno-warn-all-missed-specialisations
                        -fno-warn-implicit-prelude
                        -fno-warn-missing-import-lists

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -8,7 +8,7 @@
 , buildPackages
 , config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc865"
+, compiler ? config.haskellNix.compiler or "ghc8102"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 # Enable asserts for given packages
@@ -27,7 +27,7 @@ let
   projectPackages = lib.attrNames (haskell-nix.haskellLib.selectProjectPackages
     (haskell-nix.cabalProject {
       inherit src;
-      compiler-nix-name = compiler;
+      compiler-nix-name = "ghc8102";
     }));
 
   # This creates the Haskell package set.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "35b1ec8cd577bfc5abf7d0325f38aab01de5ed00",
-        "sha256": "0mg18i6g7nxd7qk0kaca6k8dsc3kam21772zlr19k03ff67ws55j",
+        "rev": "5fc93a3fd171bb40b97585e5eb2cab43dc467446",
+        "sha256": "0a4q51jsxsy6z1ljbfr97haffzhwsrai74mzj17ljk8d78c26kfm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/35b1ec8cd577bfc5abf7d0325f38aab01de5ed00.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/5fc93a3fd171bb40b97585e5eb2cab43dc467446.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/iohk-nix/archive/83109208047b07d5f0c103c87e6685c61c36a9f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    }
+    },
+    "nixpkgs": {
+        "branch": "nixpkgs-20.09-darwin",
+        "description": "Nix Packages collection",
+        "homepage": null,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "07e5844fdf6fe99f41229d7392ce81cfe191bcfc",
+        "sha256": "0p2z6jidm4rlp2yjfl553q234swj1vxl8z0z8ra1hm61lfrlcmb9",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/07e5844fdf6fe99f41229d7392ce81cfe191bcfc.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+   }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -20,14 +20,13 @@ let
     # These programs will be available inside the nix-shell.
     buildInputs = with haskellPackages; [
       cabal-install
-      stack
       stylish-haskell
       nix
       niv
       pkgconfig
     ] ++ lib.optionals (! minimal) [
       ghcid
-      git
+      pkgs.git
       hlint
       stylish-haskell
       weeder

--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -9,8 +9,7 @@ import           Prelude hiding ((**))
 
 import           Clay
 import qualified Clay.Media as M
-import           Clay.Selector (Selector, selectorFromText)
-import           Data.Monoid ((<>))
+import           Clay.Selector (selectorFromText)
 import           Data.Text (pack, unpack)
 import qualified Data.Text.Lazy as TL
 

--- a/src/Cardano/RTView/GUI/JS/Charts.hs
+++ b/src/Cardano/RTView/GUI/JS/Charts.hs
@@ -19,9 +19,6 @@ module Cardano.RTView.GUI.JS.Charts
     , updateNetworkUsageChartJS
     ) where
 
-import           Data.List (concat)
-import           Data.String (String)
-
 prepareChartsJS :: String
 prepareChartsJS = concat
   [ "window.charts = new Map();"

--- a/src/Cardano/RTView/GUI/Markup/Grid.hs
+++ b/src/Cardano/RTView/GUI/Markup/Grid.hs
@@ -10,7 +10,6 @@ module Cardano.RTView.GUI.Markup.Grid
 import           Control.Monad (forM)
 import           Data.Map.Strict ((!))
 import qualified Data.Map.Strict as Map
-import           Data.String (String)
 import           Data.Text (Text)
 import qualified Data.Text as T
 

--- a/src/Cardano/RTView/GUI/Markup/PageBody.hs
+++ b/src/Cardano/RTView/GUI/Markup/PageBody.hs
@@ -7,7 +7,6 @@ module Cardano.RTView.GUI.Markup.PageBody
     ) where
 
 import           Control.Monad (forM, forM_, void, when)
-import           Data.String (String)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Graphics.UI.Threepenny as UI

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -7,7 +7,6 @@ module Cardano.RTView.GUI.Markup.Pane
 
 import           Control.Monad (forM, forM_, void)
 import qualified Data.Map.Strict as Map
-import           Data.String (String)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Graphics.UI.Threepenny as UI

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -9,9 +9,8 @@ module Cardano.RTView.GUI.Updater
 import           Control.Monad (void, forM, forM_)
 import           Control.Monad.IO.Class (liftIO)
 import qualified Data.List as L
-import           Data.Maybe (Maybe (..), isJust)
+import           Data.Maybe (isJust)
 import           Data.Map.Strict ((!))
-import           Data.String (String)
 import           Data.Text (Text, pack, unpack)
 import           Data.Time.Calendar (Day (..), diffDays)
 import           Data.Time.Clock (NominalDiffTime, UTCTime (..), addUTCTime)

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -16,7 +16,6 @@ module Cardano.RTView.NodeState.Types
 import           Control.DeepSeq (NFData (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.String (String)
 import           Data.Text (Text)
 import           Data.Time.Calendar (Day (..))
 import           Data.Time.Clock (UTCTime (..))

--- a/src/Cardano/RTView/NodeState/Updater.hs
+++ b/src/Cardano/RTView/NodeState/Updater.hs
@@ -20,7 +20,6 @@ import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.MVar.Strict (MVar, modifyMVar_)
 import           Control.Monad (forever, forM_)
 import qualified Data.Aeson as A
-import           Data.List ((!!))
 import           Data.Map.Strict ((!?))
 import qualified Data.Map.Strict as Map
 import           Data.Text (Text)

--- a/test/rt-view-analyzer/src/Main.hs
+++ b/test/rt-view-analyzer/src/Main.hs
@@ -8,7 +8,6 @@ import           Control.Monad (forM_)
 
 import           Data.Text (pack)
 import           Test.WebDriver
-import           Test.WebDriver.Monad (closeOnException)
 
 import           Cardano.RTView.GUI.Elements (HTMLId (..))
 


### PR DESCRIPTION
Since `cardano-node` is already on GHC 8.10.2, it's time to move this repository as well.