### PR TITLE
CAD-2120: fix Windows encoding

### DIFF
--- a/app/cardano-rt-view.hs
+++ b/app/cardano-rt-view.hs
@@ -1,3 +1,10 @@
+{-# LANGUAGE CPP #-}
+
+#if defined(mingw32_HOST_OS)
+import           System.IO (hSetEncoding, stdout, stderr, utf8)
+import           System.Win32.Console (setConsoleCP)
+#endif
+
 import           Options.Applicative (ParserInfo, (<**>), customExecParser, fullDesc, header,
                                       helper, info, prefs, showHelpOnEmpty)
 
@@ -6,6 +13,13 @@ import           Cardano.RTView.CLI (RTViewParams, parseRTViewParams)
 
 main :: IO ()
 main = do
+#if defined(mingw32_HOST_OS)
+  -- Unfortunately, the terminal in Windows 10 isn't UTF8-ready by default.
+  -- Set encoding and code page explicitly.
+  hSetEncoding stdout utf8
+  hSetEncoding stderr utf8
+  setConsoleCP 65001
+#endif
   rtViewParams <- customExecParser (prefs showHelpOnEmpty) rtViewInfo
   runCardanoRTView rtViewParams
  where

--- a/cardano-rt-view.cabal
+++ b/cardano-rt-view.cabal
@@ -75,6 +75,8 @@ executable cardano-rt-view
   build-depends:       base >=4.12 && <5
                      , cardano-rt-view
                      , optparse-applicative
+  if os(windows)
+    build-depends:     Win32
 
   default-language:    Haskell2010
 

--- a/src/Cardano/RTView.hs
+++ b/src/Cardano/RTView.hs
@@ -27,9 +27,8 @@ import           Cardano.RTView.WebServer (launchWebServer)
 -- | Run the service.
 runCardanoRTView :: RTViewParams -> IO ()
 runCardanoRTView params' = do
-  TIO.putStrLn "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  TIO.putStrLn " RTView: real-time watching for Cardano nodes "
-  TIO.putStrLn "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  TIO.putStrLn "RTView: real-time watching for Cardano nodes"
+  TIO.putStrLn ""
 
   (config, params, acceptors) <- prepareConfigAndParams params'
 


### PR DESCRIPTION
Currently, Window 10 users are stuck with an error:

`<stdout>: commitAndReleaseBuffer: invalid argument (invalid character)`

This is because the terminal isn't UTF8-ready by default. So both encoding and code page should be specified for Windows-version automatically.