### PR TITLE
CAD-2042: Re-structure node state.

### DIFF
--- a/src/Cardano/RTView.hs
+++ b/src/Cardano/RTView.hs
@@ -51,7 +51,7 @@ runCardanoRTView params' = do
   -- Launch 3 threads:
   --   1. acceptor plugin (it launches |TraceAcceptor| plugin),
   --   2. node state updater (it gets metrics from |LogBuffer| and updates NodeState),
-  --   3. server (it serves requests from user's browser and shows nodes' metrics in the real time).
+  --   3. web server (it serves requests from user's browser and shows nodes' metrics in the real time).
   acceptorThr <- async $ launchMetricsAcceptor config accTr switchBoard
   updaterThr  <- async $ launchNodeStateUpdater tr params switchBoard be nodesStateMVar
   serverThr   <- async $ launchWebServer nodesStateMVar params acceptors

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -71,25 +71,16 @@ data ElementName
   | ElMempoolBytesPercent
   | ElMempoolMaxTxs
   | ElMempoolMaxBytes
-  | ElMemory
-  | ElMemoryMax
-  | ElMemoryMaxTotal
-  | ElMemoryPercent
-  | ElCPUPercent
   | ElCPULast
   | ElCPUNs
   | ElDiskUsageR
   | ElDiskUsageRMax
-  | ElDiskUsageRMaxTotal
   | ElDiskUsageRPercent
   | ElDiskUsageW
   | ElDiskUsageWMax
-  | ElDiskUsageWMaxTotal
   | ElDiskUsageWPercent
   | ElNetworkUsageIn
-  | ElNetworkUsageInMaxTotal
   | ElNetworkUsageOut
-  | ElNetworkUsageOutMaxTotal
   | ElRTSMemoryAllocated
   | ElRTSMemoryUsed
   | ElRTSMemoryUsedPercent
@@ -117,27 +108,24 @@ data ElementValue
   | ElementWord64  !Word64
   | ElementDouble  !Double
   | ElementString  !String
+  | ElementText    !Text
   deriving (Generic, NFData)
 
 -- | An item for each connected peer, contains a parent element
 --   and list of child elements.
-data PeerInfoItem
-  = PeerInfoItem
-      { piItem      :: !Element
-      , piItemElems :: !PeerInfoElements
-      }
-  deriving (Generic, NFData)
+data PeerInfoItem = PeerInfoItem
+  { piItem      :: !Element
+  , piItemElems :: !PeerInfoElements
+  } deriving (Generic, NFData)
 
-data PeerInfoElements
-  = PeerInfoElements
-      { pieEndpoint   :: !Element
-      , pieBytesInF   :: !Element
-      , pieReqsInF    :: !Element
-      , pieBlocksInF  :: !Element
-      , pieSlotNumber :: !Element
-      , pieStatus     :: !Element
-      }
-  deriving (Generic, NFData)
+data PeerInfoElements = PeerInfoElements
+  { pieEndpoint   :: !Element
+  , pieBytesInF   :: !Element
+  , pieReqsInF    :: !Element
+  , pieBlocksInF  :: !Element
+  , pieSlotNumber :: !Element
+  , pieStatus     :: !Element
+  } deriving (Generic, NFData)
 
 -- | HTML elements identifiers, we use them in HTML, CSS and JS FFI.
 

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -24,52 +24,43 @@ mkNodePane nameOfNode = do
   -- Create |Element|s containing node state (info, metrics).
   -- These elements will be part of the complete page,
   -- later they will be updated by acceptor thread.
-  elNodeProtocol            <- string ""
-  elNodeVersion             <- string ""
-  elNodePlatform            <- string ""
-  elActiveNode              <- string "-"
-  elUptime                  <- string "00:00:00"
-  elEpoch                   <- string "0"
-  elSlot                    <- string "0"
-  elBlocksNumber            <- string "0"
-  elBlocksForgedNumber      <- string "0"
-  elNodeCannotForge         <- string "0"
-  elChainDensity            <- string "0"
-  elNodeIsLeaderNumber      <- string "0"
-  elSlotsMissedNumber       <- string "0"
-  elTxsProcessed            <- string "0"
-  elTraceAcceptorEndpoint   <- string "0"
-  elOpCertStartKESPeriod    <- string "0"
-  elOpCertExpiryKESPeriod   <- string "0"
-  elCurrentKESPeriod        <- string "0"
-  elRemainingKESPeriods     <- string "0"
+  elNodeProtocol              <- string ""
+  elNodeVersion               <- string ""
+  elNodePlatform              <- string ""
+  elActiveNode                <- string "-"
+  elUptime                    <- string "00:00:00"
+  elEpoch                     <- string "0"
+  elSlot                      <- string "0"
+  elBlocksNumber              <- string "0"
+  elBlocksForgedNumber        <- string "0"
+  elNodeCannotForge           <- string "0"
+  elChainDensity              <- string "0"
+  elNodeIsLeaderNumber        <- string "0"
+  elSlotsMissedNumber         <- string "0"
+  elTxsProcessed              <- string "0"
+  elTraceAcceptorEndpoint     <- string "0"
+  elOpCertStartKESPeriod      <- string "0"
+  elOpCertExpiryKESPeriod     <- string "0"
+  elCurrentKESPeriod          <- string "0"
+  elRemainingKESPeriods       <- string "0"
   elRemainingKESPeriodsInDays <- string "0"
-  elMempoolTxsNumber        <- string "0"
-  elMempoolTxsPercent       <- string "0"
-  elMempoolBytes            <- string "0"
-  elMempoolBytesPercent     <- string "0"
-  elMempoolMaxTxs           <- string "0"
-  elMempoolMaxBytes         <- string "0"
-  elMemory                  <- string "0"
-  elMemoryMax               <- string "0"
-  elMemoryMaxTotal          <- string "0"
-  elMemoryPercent           <- string "0"
-  elCPUPercent              <- string "0"
-  elDiskUsageR              <- string "0"
-  elDiskUsageRMaxTotal      <- string "0"
-  elDiskUsageW              <- string "0"
-  elDiskUsageWMaxTotal      <- string "0"
-  elNetworkUsageIn          <- string "0"
-  elNetworkUsageInMaxTotal  <- string "0"
-  elNetworkUsageOut         <- string "0"
-  elNetworkUsageOutMaxTotal <- string "0"
-  elRTSMemoryAllocated      <- string "0"
-  elRTSMemoryUsed           <- string "0"
-  elRTSMemoryUsedPercent    <- string "0"
-  elRTSGcCpu                <- string "0"
-  elRTSGcElapsed            <- string "0"
-  elRTSGcNum                <- string "0"
-  elRTSGcMajorNum           <- string "0"
+  elMempoolTxsNumber          <- string "0"
+  elMempoolTxsPercent         <- string "0"
+  elMempoolBytes              <- string "0"
+  elMempoolBytesPercent       <- string "0"
+  elMempoolMaxTxs             <- string "0"
+  elMempoolMaxBytes           <- string "0"
+  elDiskUsageR                <- string "0"
+  elDiskUsageW                <- string "0"
+  elNetworkUsageIn            <- string "0"
+  elNetworkUsageOut           <- string "0"
+  elRTSMemoryAllocated        <- string "0"
+  elRTSMemoryUsed             <- string "0"
+  elRTSMemoryUsedPercent      <- string "0"
+  elRTSGcCpu                  <- string "0"
+  elRTSGcElapsed              <- string "0"
+  elRTSGcNum                  <- string "0"
+  elRTSGcMajorNum             <- string "0"
 
   -- Progress bars.
   elMempoolBytesProgress    <- UI.div #. [ProgressBar] #+
@@ -511,19 +502,10 @@ mkNodePane nameOfNode = do
           , (ElMempoolBytesPercent,     elMempoolBytesPercent)
           , (ElMempoolMaxTxs,           elMempoolMaxTxs)
           , (ElMempoolMaxBytes,         elMempoolMaxBytes)
-          , (ElMemory,                  elMemory)
-          , (ElMemoryMax,               elMemoryMax)
-          , (ElMemoryMaxTotal,          elMemoryMaxTotal)
-          , (ElMemoryPercent,           elMemoryPercent)
-          , (ElCPUPercent,              elCPUPercent)
           , (ElDiskUsageR,              elDiskUsageR)
-          , (ElDiskUsageRMaxTotal,      elDiskUsageRMaxTotal)
           , (ElDiskUsageW,              elDiskUsageW)
-          , (ElDiskUsageWMaxTotal,      elDiskUsageWMaxTotal)
           , (ElNetworkUsageIn,          elNetworkUsageIn)
-          , (ElNetworkUsageInMaxTotal,  elNetworkUsageInMaxTotal)
           , (ElNetworkUsageOut,         elNetworkUsageOut)
-          , (ElNetworkUsageOutMaxTotal, elNetworkUsageOutMaxTotal)
           , (ElRTSMemoryAllocated,      elRTSMemoryAllocated)
           , (ElRTSMemoryUsed,           elRTSMemoryUsed)
           , (ElRTSMemoryUsedPercent,    elRTSMemoryUsedPercent)

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -4,11 +4,18 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.RTView.NodeState.Types
-    ( NodeError (..)
-    , NodesState
-    , NodeState (..)
-    , NodeInfo (..)
+    ( NodesState
+    , PeerMetrics (..)
+    , MempoolMetrics (..)
+    , ForgeMetrics (..)
+    , ResourcesMetrics (..)
+    , RTSMetrics (..)
+    , BlockchainMetrics (..)
+    , KESMetrics (..)
     , NodeMetrics (..)
+    , ErrorsMetrics (..)
+    , NodeState (..)
+    , NodeError (..)
     , PeerInfo (..)
     , defaultNodesState
     ) where
@@ -29,145 +36,194 @@ import           Cardano.BM.Data.Severity (Severity)
 
 type NodesState = Map Text NodeState
 
-data NodeState
-  = NodeState
-      { nsInfo    :: !NodeInfo
-      , nsMetrics :: !NodeMetrics
-      }
-  deriving (Generic, NFData, Show)
-
-data PeerInfo
-  = PeerInfo
-      { piEndpoint   :: !String
-      , piBytesInF   :: !String
-      , piReqsInF    :: !String
-      , piBlocksInF  :: !String
-      , piSlotNumber :: !String
-      , piStatus     :: !String
-      }
-  deriving (Eq, Generic, NFData, Show)
+data PeerInfo = PeerInfo
+  { piEndpoint   :: !String
+  , piBytesInF   :: !String
+  , piReqsInF    :: !String
+  , piBlocksInF  :: !String
+  , piSlotNumber :: !String
+  , piStatus     :: !String
+  } deriving (Eq, Generic, NFData)
 
 -- Severity type already has Generic instance.
 instance NFData Severity
 
-data NodeError
-  = NodeError
-      { eTimestamp :: !UTCTime
-      , eSeverity  :: !Severity
-      , eMessage   :: !String
-      }
-  deriving (Generic, NFData, Show)
+data NodeError = NodeError
+  { eTimestamp :: !UTCTime
+  , eSeverity  :: !Severity
+  , eMessage   :: !String
+  } deriving (Generic, NFData)
 
-data NodeInfo
-  = NodeInfo
-      { niNodeProtocol                   :: !String
-      , niNodeVersion                    :: !String
-      , niNodeCommit                     :: !String
-      , niNodeShortCommit                :: !String
-      , niNodePlatform                   :: !String
-      , niUpTime                         :: !Word64
-      , niUpTimeLastUpdate               :: !Word64
-      , niEpoch                          :: !Integer
-      , niEpochLastUpdate                :: !Word64
-      , niSlot                           :: !Integer
-      , niSlotLastUpdate                 :: !Word64
-      , niNodeIsLeaderNum                :: !Integer
-      , niNodeIsLeaderNumLastUpdate      :: !Word64
-      , niSlotsMissedNumber              :: !Integer
-      , niSlotsMissedNumberLastUpdate    :: !Word64
-      , niBlocksNumber                   :: !Integer
-      , niBlocksNumberLastUpdate         :: !Word64
-      , niBlocksForgedNumber             :: !Integer
-      , niBlocksForgedNumberLastUpdate   :: !Word64
-      , niNodeCannotForge                :: !Integer
-      , niChainDensity                   :: !Double
-      , niChainDensityLastUpdate         :: !Word64
-      , niTxsProcessed                   :: !Integer
-      , niPeersInfo                      :: ![PeerInfo]
-      , niTraceAcceptorHost              :: !String
-      , niTraceAcceptorPort              :: !String
-      , niRemainingKESPeriods            :: !Integer
-      , niRemainingKESPeriodsInDays      :: !Integer
-      , niRemainingKESPeriodsLastUpdate  :: !Word64
-      , niOpCertStartKESPeriod           :: !Integer
-      , niOpCertStartKESPeriodLastUpdate :: !Word64
-      , niOpCertExpiryKESPeriod           :: !Integer
-      , niOpCertExpiryKESPeriodLastUpdate :: !Word64
-      , niCurrentKESPeriod               :: !Integer
-      , niCurrentKESPeriodLastUpdate     :: !Word64
-      , niNodeErrors                     :: ![NodeError]
-      }
-  deriving (Generic, NFData, Show)
+data NodeState = NodeState
+  { peersMetrics      :: !PeerMetrics
+  , mempoolMetrics    :: !MempoolMetrics
+  , forgeMetrics      :: !ForgeMetrics
+  , resourcesMetrics  :: !ResourcesMetrics
+  , rtsMetrics        :: !RTSMetrics
+  , blockchainMetrics :: !BlockchainMetrics
+  , kesMetrics        :: !KESMetrics
+  , nodeMetrics       :: !NodeMetrics
+  , nodeErrors        :: !ErrorsMetrics
+  } deriving (Generic, NFData)
 
-data NodeMetrics
-  = NodeMetrics
-      { nmMempoolTxsNumber          :: !Word64
-      , nmMempoolTxsPercent         :: !Double
-      , nmMempoolBytes              :: !Word64
-      , nmMempoolBytesPercent       :: !Double
-      , nmMempoolMaxTxs             :: !Integer
-      , nmMempoolMaxBytes           :: !Integer
-      , nmMemory                    :: !Double
-      , nmMemoryMax                 :: !Double
-      , nmMemoryMaxTotal            :: !Double
-      , nmMemoryPercent             :: !Double
-      , nmMemoryLastUpdate          :: !Word64
-      , nmCPUPercent                :: !Double
-      , nmCPULast                   :: !Integer
-      , nmCPUNs                     :: !Word64
-      , nmCPULastUpdate             :: !Word64
-      , nmDiskUsageR                :: !Double
-      , nmDiskUsageRMax             :: !Double
-      , nmDiskUsageRMaxTotal        :: !Double
-      , nmDiskUsageRPercent         :: !Double
-      , nmDiskUsageRLast            :: !Word64
-      , nmDiskUsageRNs              :: !Word64
-      , nmDiskUsageRAdaptTime       :: !UTCTime
-      , nmDiskUsageRLastUpdate      :: !Word64
-      , nmDiskUsageW                :: !Double
-      , nmDiskUsageWMax             :: !Double
-      , nmDiskUsageWMaxTotal        :: !Double
-      , nmDiskUsageWPercent         :: !Double
-      , nmDiskUsageWLast            :: !Word64
-      , nmDiskUsageWNs              :: !Word64
-      , nmDiskUsageWAdaptTime       :: !UTCTime
-      , nmDiskUsageWLastUpdate      :: !Word64
-      , nmNetworkUsageIn            :: !Double
-      , nmNetworkUsageInPercent     :: !Double
-      , nmNetworkUsageInMax         :: !Double
-      , nmNetworkUsageInMaxTotal    :: !Double
-      , nmNetworkUsageInLast        :: !Word64
-      , nmNetworkUsageInNs          :: !Word64
-      , nmNetworkUsageInLastUpdate  :: !Word64
-      , nmNetworkUsageOut           :: !Double
-      , nmNetworkUsageOutPercent    :: !Double
-      , nmNetworkUsageOutMax        :: !Double
-      , nmNetworkUsageOutMaxTotal   :: !Double
-      , nmNetworkUsageOutLast       :: !Word64
-      , nmNetworkUsageOutNs         :: !Word64
-      , nmNetworkUsageOutLastUpdate :: !Word64
-      , nmRTSMemoryAllocated        :: !Double
-      , nmRTSMemoryUsed             :: !Double
-      , nmRTSMemoryUsedPercent      :: !Double
-      , nmRTSMemoryLastUpdate       :: !Word64
-      , nmRTSGcCpu                  :: !Double
-      , nmRTSGcCpuLastUpdate        :: !Word64
-      , nmRTSGcElapsed              :: !Double
-      , nmRTSGcElapsedLastUpdate    :: !Word64
-      , nmRTSGcNum                  :: !Integer
-      , nmRTSGcNumLastUpdate        :: !Word64
-      , nmRTSGcMajorNum             :: !Integer
-      , nmRTSGcMajorNumLastUpdate   :: !Word64
-      }
-  deriving (Generic, NFData, Show)
+data PeerMetrics = PeerMetrics
+  { peersInfo :: ![PeerInfo]
+  , peersInfoChanged :: !Bool
+  } deriving (Generic, NFData)
+
+data MempoolMetrics = MempoolMetrics
+  { mempoolTxsNumber        :: !Word64
+  , mempoolTxsNumberChanged :: !Bool
+  , mempoolTxsPercent       :: !Double
+  , mempoolBytes            :: !Word64
+  , mempoolBytesChanged     :: !Bool
+  , mempoolBytesPercent     :: !Double
+  , mempoolMaxTxs           :: !Integer
+  , mempoolMaxBytes         :: !Integer
+  , txsProcessed            :: !Integer
+  , txsProcessedChanged     :: !Bool
+  } deriving (Generic, NFData)
+
+data ForgeMetrics = ForgeMetrics
+  { nodeIsLeaderNum              :: !Integer
+  , nodeIsLeaderNumChanged       :: !Bool
+  , nodeIsLeaderNumLastUpdate    :: !Word64
+  , slotsMissedNumber            :: !Integer
+  , slotsMissedNumberChanged     :: !Bool
+  , slotsMissedNumberLastUpdate  :: !Word64
+  , nodeCannotForge              :: !Integer
+  , nodeCannotForgeChanged       :: !Bool
+  , blocksForgedNumber           :: !Integer
+  , blocksForgedNumberChanged    :: !Bool
+  , blocksForgedNumberLastUpdate :: !Word64
+  } deriving (Generic, NFData)
+
+data ResourcesMetrics = ResourcesMetrics
+  { memory                    :: !Double
+  , memoryChanged             :: !Bool
+  , memoryMax                 :: !Double
+  , memoryMaxTotal            :: !Double
+  , memoryPercent             :: !Double
+  , memoryLastUpdate          :: !Word64
+  , cpuPercent                :: !Double
+  , cpuPercentChanged         :: !Bool
+  , cpuLast                   :: !Integer
+  , cpuNs                     :: !Word64
+  , cpuLastUpdate             :: !Word64
+  , diskUsageR                :: !Double
+  , diskUsageRChanged         :: !Bool
+  , diskUsageRMax             :: !Double
+  , diskUsageRMaxTotal        :: !Double
+  , diskUsageRPercent         :: !Double
+  , diskUsageRLast            :: !Word64
+  , diskUsageRNs              :: !Word64
+  , diskUsageRAdaptTime       :: !UTCTime
+  , diskUsageRLastUpdate      :: !Word64
+  , diskUsageW                :: !Double
+  , diskUsageWChanged         :: !Bool
+  , diskUsageWMax             :: !Double
+  , diskUsageWMaxTotal        :: !Double
+  , diskUsageWPercent         :: !Double
+  , diskUsageWLast            :: !Word64
+  , diskUsageWNs              :: !Word64
+  , diskUsageWAdaptTime       :: !UTCTime
+  , diskUsageWLastUpdate      :: !Word64
+  , networkUsageIn            :: !Double
+  , networkUsageInChanged     :: !Bool
+  , networkUsageInPercent     :: !Double
+  , networkUsageInMax         :: !Double
+  , networkUsageInMaxTotal    :: !Double
+  , networkUsageInLast        :: !Word64
+  , networkUsageInNs          :: !Word64
+  , networkUsageInLastUpdate  :: !Word64
+  , networkUsageOut           :: !Double
+  , networkUsageOutChanged    :: !Bool
+  , networkUsageOutPercent    :: !Double
+  , networkUsageOutMax        :: !Double
+  , networkUsageOutMaxTotal   :: !Double
+  , networkUsageOutLast       :: !Word64
+  , networkUsageOutNs         :: !Word64
+  , networkUsageOutLastUpdate :: !Word64
+  } deriving (Generic, NFData)
+
+data RTSMetrics = RTSMetrics
+  { rtsMemoryAllocated        :: !Double
+  , rtsMemoryAllocatedChanged :: !Bool
+  , rtsMemoryUsed             :: !Double
+  , rtsMemoryUsedChanged      :: !Bool
+  , rtsMemoryUsedPercent      :: !Double
+  , rtsMemoryLastUpdate       :: !Word64
+  , rtsGcCpu                  :: !Double
+  , rtsGcCpuChanged           :: !Bool
+  , rtsGcCpuLastUpdate        :: !Word64
+  , rtsGcElapsed              :: !Double
+  , rtsGcElapsedChanged       :: !Bool
+  , rtsGcElapsedLastUpdate    :: !Word64
+  , rtsGcNum                  :: !Integer
+  , rtsGcNumChanged           :: !Bool
+  , rtsGcNumLastUpdate        :: !Word64
+  , rtsGcMajorNum             :: !Integer
+  , rtsGcMajorNumChanged      :: !Bool
+  , rtsGcMajorNumLastUpdate   :: !Word64
+  } deriving (Generic, NFData)
+
+data BlockchainMetrics = BlockchainMetrics
+  { epoch                  :: !Integer
+  , epochChanged           :: !Bool
+  , epochLastUpdate        :: !Word64
+  , slot                   :: !Integer
+  , slotChanged            :: !Bool
+  , slotLastUpdate         :: !Word64
+  , blocksNumber           :: !Integer
+  , blocksNumberChanged    :: !Bool
+  , blocksNumberLastUpdate :: !Word64
+  , chainDensity           :: !Double
+  , chainDensityChanged    :: !Bool
+  , chainDensityLastUpdate :: !Word64
+  } deriving (Generic, NFData)
+
+data KESMetrics = KESMetrics
+  { remainingKESPeriods             :: !Integer
+  , remainingKESPeriodsChanged      :: !Bool
+  , remainingKESPeriodsInDays       :: !Integer
+  , remainingKESPeriodsLastUpdate   :: !Word64
+  , opCertStartKESPeriod            :: !Integer
+  , opCertStartKESPeriodChanged     :: !Bool
+  , opCertStartKESPeriodLastUpdate  :: !Word64
+  , opCertExpiryKESPeriod           :: !Integer
+  , opCertExpiryKESPeriodChanged    :: !Bool
+  , opCertExpiryKESPeriodLastUpdate :: !Word64
+  , currentKESPeriod                :: !Integer
+  , currentKESPeriodChanged         :: !Bool
+  , currentKESPeriodLastUpdate      :: !Word64
+  } deriving (Generic, NFData)
+
+data NodeMetrics = NodeMetrics
+  { nodeProtocol        :: !Text
+  , nodeProtocolChanged :: !Bool
+  , nodeVersion         :: !Text
+  , nodeVersionChanged  :: !Bool
+  , nodeCommit          :: !Text
+  , nodeCommitChanged   :: !Bool
+  , nodeShortCommit     :: !Text
+  , nodePlatform        :: !Text
+  , nodePlatformChanged :: !Bool
+  , upTime              :: !Word64
+  , upTimeLastUpdate    :: !Word64
+  } deriving (Generic, NFData)
+
+data ErrorsMetrics = ErrorsMetrics
+  { errors        :: ![NodeError]
+  , errorsChanged :: !Bool
+  } deriving (Generic, NFData)
 
 defaultNodesState
   :: Configuration
   -> IO NodesState
 defaultNodesState config =
   CM.getAcceptAt config >>= \case
-    Just remoteAddresses -> do
-      return $ Map.fromList [(name, defaultNodeState) | (RemoteAddrNamed name _) <- remoteAddresses]
+    Just addrs -> do
+      return $ Map.fromList [(name, defaultNodeState) | (RemoteAddrNamed name _) <- addrs]
     Nothing ->
       -- Actually it's impossible, because at this point we already know
       -- that at least one |TraceAcceptor| is defined in the config.
@@ -175,107 +231,155 @@ defaultNodesState config =
 
 defaultNodeState :: NodeState
 defaultNodeState = NodeState
-  { nsInfo    = defaultNodeInfo
-  , nsMetrics = defaultNodeMetrics
-  }
-
-defaultNodeInfo :: NodeInfo
-defaultNodeInfo = NodeInfo
-  { niNodeProtocol                  = "—"
-  , niNodeVersion                   = "—"
-  , niNodeCommit                    = "—"
-  , niNodeShortCommit               = "—"
-  , niNodePlatform                  = "—"
-  , niUpTime                        = 0
-  , niUpTimeLastUpdate              = 0
-  , niEpoch                         = 0
-  , niEpochLastUpdate               = 0
-  , niSlot                          = 0
-  , niSlotLastUpdate                = 0
-  , niNodeIsLeaderNum               = 0
-  , niNodeIsLeaderNumLastUpdate     = 0
-  , niSlotsMissedNumber             = 0
-  , niSlotsMissedNumberLastUpdate   = 0
-  , niBlocksNumber                  = 0
-  , niBlocksNumberLastUpdate        = 0
-  , niBlocksForgedNumber            = 0
-  , niBlocksForgedNumberLastUpdate  = 0
-  , niNodeCannotForge               = 0
-  , niChainDensity                  = 0.0
-  , niChainDensityLastUpdate        = 0
-  , niTxsProcessed                  = 0
-  , niPeersInfo                     = []
-  , niTraceAcceptorHost             = "-"
-  , niTraceAcceptorPort             = "-"
-  , niRemainingKESPeriods           = 9999999999
-  , niRemainingKESPeriodsInDays     = 9999999999
-  , niRemainingKESPeriodsLastUpdate = 0
-  , niOpCertStartKESPeriod          = 9999999999
-  , niOpCertStartKESPeriodLastUpdate = 0
-  , niOpCertExpiryKESPeriod          = 9999999999
-  , niOpCertExpiryKESPeriodLastUpdate = 0
-  , niCurrentKESPeriod              = 9999999999
-  , niCurrentKESPeriodLastUpdate    = 0
-  , niNodeErrors                    = []
-  }
-
-defaultNodeMetrics :: NodeMetrics
-defaultNodeMetrics = NodeMetrics
-  { nmMempoolTxsNumber          = 0
-  , nmMempoolTxsPercent         = 0.0
-  , nmMempoolBytes              = 0
-  , nmMempoolBytesPercent       = 0.0
-  , nmMempoolMaxTxs             = 1
-  , nmMempoolMaxBytes           = 1
-  , nmMemory                    = 0.0
-  , nmMemoryMax                 = 0.1
-  , nmMemoryMaxTotal            = 200.0
-  , nmMemoryPercent             = 0.0
-  , nmMemoryLastUpdate          = 0
-  , nmCPUPercent                = 0.5
-  , nmCPULast                   = 0
-  , nmCPUNs                     = 10000
-  , nmCPULastUpdate             = 0
-  , nmDiskUsageR                = 0.0
-  , nmDiskUsageRMax             = 0.0
-  , nmDiskUsageRMaxTotal        = 0.0
-  , nmDiskUsageRPercent         = 0.0
-  , nmDiskUsageRLast            = 0
-  , nmDiskUsageRNs              = 10000
-  , nmDiskUsageRAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
-  , nmDiskUsageRLastUpdate      = 0
-  , nmDiskUsageW                = 0.0
-  , nmDiskUsageWMax             = 0.0
-  , nmDiskUsageWMaxTotal        = 0.0
-  , nmDiskUsageWPercent         = 0.0
-  , nmDiskUsageWLast            = 0
-  , nmDiskUsageWNs              = 10000
-  , nmDiskUsageWAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
-  , nmDiskUsageWLastUpdate      = 0
-  , nmNetworkUsageIn            = 0.0
-  , nmNetworkUsageInPercent     = 0.0
-  , nmNetworkUsageInMax         = 0.0
-  , nmNetworkUsageInMaxTotal    = 0.0
-  , nmNetworkUsageInLast        = 0
-  , nmNetworkUsageInNs          = 10000
-  , nmNetworkUsageInLastUpdate  = 0
-  , nmNetworkUsageOut           = 0.0
-  , nmNetworkUsageOutPercent    = 0.0
-  , nmNetworkUsageOutMax        = 0.0
-  , nmNetworkUsageOutMaxTotal   = 0.0
-  , nmNetworkUsageOutLast       = 0
-  , nmNetworkUsageOutNs         = 10000
-  , nmNetworkUsageOutLastUpdate = 0
-  , nmRTSMemoryAllocated        = 1.0
-  , nmRTSMemoryUsed             = 0.1
-  , nmRTSMemoryUsedPercent      = 1.0
-  , nmRTSMemoryLastUpdate       = 0
-  , nmRTSGcCpu                  = 0.1
-  , nmRTSGcCpuLastUpdate        = 0
-  , nmRTSGcElapsed              = 0.1
-  , nmRTSGcElapsedLastUpdate    = 0
-  , nmRTSGcNum                  = 0
-  , nmRTSGcNumLastUpdate        = 0
-  , nmRTSGcMajorNum             = 0
-  , nmRTSGcMajorNumLastUpdate   = 0
+  { peersMetrics =
+      PeerMetrics
+        { peersInfo        = []
+        , peersInfoChanged = True
+        }
+  , mempoolMetrics =
+      MempoolMetrics
+        { mempoolTxsNumber        = 0
+        , mempoolTxsNumberChanged = True
+        , mempoolTxsPercent       = 0.0
+        , mempoolBytes            = 0
+        , mempoolBytesChanged     = True
+        , mempoolBytesPercent     = 0.0
+        , mempoolMaxTxs           = 1
+        , mempoolMaxBytes         = 1
+        , txsProcessed            = 0
+        , txsProcessedChanged     = True
+        }
+  , forgeMetrics =
+      ForgeMetrics
+        { nodeIsLeaderNum              = 0
+        , nodeIsLeaderNumChanged       = True
+        , nodeIsLeaderNumLastUpdate    = 0
+        , slotsMissedNumber            = 0
+        , slotsMissedNumberChanged     = True
+        , slotsMissedNumberLastUpdate  = 0
+        , nodeCannotForge              = 0
+        , nodeCannotForgeChanged       = True
+        , blocksForgedNumber           = 0
+        , blocksForgedNumberChanged    = True
+        , blocksForgedNumberLastUpdate = 0
+        }
+  , resourcesMetrics =
+      ResourcesMetrics
+        { memory                    = 0.0
+        , memoryChanged             = True
+        , memoryMax                 = 0.1
+        , memoryMaxTotal            = 200.0
+        , memoryPercent             = 0.0
+        , memoryLastUpdate          = 0
+        , cpuPercent                = 0.5
+        , cpuPercentChanged         = True
+        , cpuLast                   = 0
+        , cpuNs                     = 10000
+        , cpuLastUpdate             = 0
+        , diskUsageR                = 0.0
+        , diskUsageRChanged         = True
+        , diskUsageRMax             = 0.0
+        , diskUsageRMaxTotal        = 0.0
+        , diskUsageRPercent         = 0.0
+        , diskUsageRLast            = 0
+        , diskUsageRNs              = 10000
+        , diskUsageRAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
+        , diskUsageRLastUpdate      = 0
+        , diskUsageW                = 0.0
+        , diskUsageWChanged         = True
+        , diskUsageWMax             = 0.0
+        , diskUsageWMaxTotal        = 0.0
+        , diskUsageWPercent         = 0.0
+        , diskUsageWLast            = 0
+        , diskUsageWNs              = 10000
+        , diskUsageWAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
+        , diskUsageWLastUpdate      = 0
+        , networkUsageIn            = 0.0
+        , networkUsageInChanged     = True
+        , networkUsageInPercent     = 0.0
+        , networkUsageInMax         = 0.0
+        , networkUsageInMaxTotal    = 0.0
+        , networkUsageInLast        = 0
+        , networkUsageInNs          = 10000
+        , networkUsageInLastUpdate  = 0
+        , networkUsageOut           = 0.0
+        , networkUsageOutChanged    = True
+        , networkUsageOutPercent    = 0.0
+        , networkUsageOutMax        = 0.0
+        , networkUsageOutMaxTotal   = 0.0
+        , networkUsageOutLast       = 0
+        , networkUsageOutNs         = 10000
+        , networkUsageOutLastUpdate = 0
+        }
+  , rtsMetrics =
+      RTSMetrics
+        { rtsMemoryAllocated        = 1.0
+        , rtsMemoryAllocatedChanged = True
+        , rtsMemoryUsed             = 0.1
+        , rtsMemoryUsedChanged      = True
+        , rtsMemoryUsedPercent      = 1.0
+        , rtsMemoryLastUpdate       = 0
+        , rtsGcCpu                  = 0.1
+        , rtsGcCpuChanged           = True
+        , rtsGcCpuLastUpdate        = 0
+        , rtsGcElapsed              = 0.1
+        , rtsGcElapsedChanged       = True
+        , rtsGcElapsedLastUpdate    = 0
+        , rtsGcNum                  = 0
+        , rtsGcNumChanged           = True
+        , rtsGcNumLastUpdate        = 0
+        , rtsGcMajorNum             = 0
+        , rtsGcMajorNumChanged      = True
+        , rtsGcMajorNumLastUpdate   = 0
+        }
+  , blockchainMetrics =
+      BlockchainMetrics
+        { epoch                  = 0
+        , epochChanged           = True
+        , epochLastUpdate        = 0
+        , slot                   = 0
+        , slotChanged            = True
+        , slotLastUpdate         = 0
+        , blocksNumber           = 0
+        , blocksNumberChanged    = True
+        , blocksNumberLastUpdate = 0
+        , chainDensity           = 0
+        , chainDensityChanged    = True
+        , chainDensityLastUpdate = 0
+        }
+  , kesMetrics =
+      KESMetrics
+        { remainingKESPeriods             = 9999999999
+        , remainingKESPeriodsChanged      = True
+        , remainingKESPeriodsInDays       = 9999999999
+        , remainingKESPeriodsLastUpdate   = 0
+        , opCertStartKESPeriod            = 9999999999
+        , opCertStartKESPeriodChanged     = True
+        , opCertStartKESPeriodLastUpdate  = 0
+        , opCertExpiryKESPeriod           = 9999999999
+        , opCertExpiryKESPeriodChanged    = True
+        , opCertExpiryKESPeriodLastUpdate = 0
+        , currentKESPeriod                = 9999999999
+        , currentKESPeriodChanged         = True
+        , currentKESPeriodLastUpdate      = 0
+        }
+  , nodeMetrics =
+      NodeMetrics
+        { nodeProtocol        = "-"
+        , nodeProtocolChanged = True
+        , nodeVersion         = "-"
+        , nodeVersionChanged  = True
+        , nodeCommit          = "-"
+        , nodeCommitChanged   = True
+        , nodeShortCommit     = "-"
+        , nodePlatform        = "-"
+        , nodePlatformChanged = True
+        , upTime              = 0
+        , upTimeLastUpdate    = 0
+        }
+  , nodeErrors =
+      ErrorsMetrics
+        { errors        = []
+        , errorsChanged = True
+        }
   }

--- a/src/Cardano/RTView/WebServer.hs
+++ b/src/Cardano/RTView/WebServer.hs
@@ -54,7 +54,7 @@ mainPage nsMVar params acceptors window = do
 
   -- Start the timer for GUI update. Every second it will
   -- call a function which updates node state elements on the page.
-  guiUpdateTimer <- timer # set interval 2000 -- Every 2 s.
+  guiUpdateTimer <- timer # set interval 1000
   void $ onEvent (tick guiUpdateTimer) $ \_ -> do
     newState <- liftIO $ readMVar nsMVar
     updateGUI window newState params acceptors (nodesStateElems, gridNodesStateElems)


### PR DESCRIPTION
Previously, the internal nodes' state was represented as two very big structures. Now it is separated into a few structures, based on logical grouping.

Additionally, some cleanup was done: remove unused `Element`s, simplify many functions.

_Please note that some important changes related to internal nodes' state will be made again, in the future._