### PR TITLE
CAD-2198: prepare for nodeBasicInfo.

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -106,24 +106,6 @@ Now, indicate a host of machine RTView will be launched on (default is 0.0.0.0):
 
 If your nodes are launched on the same machine with RTView, you can choose the default address. But if RTView will be launched on another machine, please specify its reachable public IP address. It will allow your nodes to connect with RTView. In this case, it is assumed that a machine with RTView is accessible using that IP address.
 
-The next question is:
-
-```
-Indicate the number of slots in a KES period (default is 129600):
-```
-
-The number of slots in a KES period is a constant which is taken from your genesis file, please see `slotsPerKESPeriod` value.
-
-The next question is:
-
-```
-Indicate the length of slot, in seconds (default is 1):
-```
-
-The length of slot, in seconds, is a constant which is taken from your genesis file as well, please see `slotLength` value.
-
-These two KES-related values are required to calculate remaining KES periods in days (this value will be shown in `KES` tab in Pane view mode).
-
 The last question is:
 
 ```

--- a/src/Cardano/RTView.hs
+++ b/src/Cardano/RTView.hs
@@ -53,7 +53,7 @@ runCardanoRTView params' = do
   --   2. node state updater (it gets metrics from |LogBuffer| and updates NodeState),
   --   3. web server (it serves requests from user's browser and shows nodes' metrics in the real time).
   acceptorThr <- async $ launchMetricsAcceptor config accTr switchBoard
-  updaterThr  <- async $ launchNodeStateUpdater tr params switchBoard be nodesStateMVar
+  updaterThr  <- async $ launchNodeStateUpdater tr switchBoard be nodesStateMVar
   serverThr   <- async $ launchWebServer nodesStateMVar params acceptors
 
   void $ waitAnyCancel [acceptorThr, updaterThr, serverThr]

--- a/src/Cardano/RTView/CLI.hs
+++ b/src/Cardano/RTView/CLI.hs
@@ -7,8 +7,6 @@ module Cardano.RTView.CLI
     , defaultRTVConfig
     , defaultRTVStatic
     , defaultRTVPort
-    , defaultRTVSlotsPerKESPeriod
-    , defaultRTVSlotLength
     , defaultRTVNodeInfoLife
     , defaultRTVBlockchainInfoLife
     , defaultRTVResourcesInfoLife
@@ -17,7 +15,7 @@ module Cardano.RTView.CLI
     ) where
 
 import           Data.Word (Word64)
-import           Data.Yaml (FromJSON (..), ToJSON, (.:), (.:?), (.!=), withObject)
+import           Data.Yaml (FromJSON (..), ToJSON, (.:), withObject)
 import           GHC.Generics (Generic)
 
 import           Options.Applicative (HasCompleter, HasMetavar, HasName, HasValue, Mod, Parser,
@@ -30,8 +28,6 @@ data RTViewParams
       { rtvConfig             :: !FilePath
       , rtvStatic             :: !FilePath
       , rtvPort               :: !Int
-      , rtvSlotsPerKESPeriod  :: !Int
-      , rtvSlotLength         :: !Int
       , rtvNodeInfoLife       :: !Word64
       , rtvBlockchainInfoLife :: !Word64
       , rtvResourcesInfoLife  :: !Word64
@@ -43,8 +39,6 @@ instance FromJSON RTViewParams where
     <$> v .:  "rtvConfig"
     <*> v .:  "rtvStatic"
     <*> v .:  "rtvPort"
-    <*> v .:? "rtvSlotsPerKESPeriod" .!= defaultRTVSlotsPerKESPeriod
-    <*> v .:? "rtvSlotLength"        .!= defaultRTVSlotLength
     <*> v .:  "rtvNodeInfoLife"
     <*> v .:  "rtvBlockchainInfoLife"
     <*> v .:  "rtvResourcesInfoLife"
@@ -55,8 +49,6 @@ defaultRTViewParams = RTViewParams
   { rtvConfig             = defaultRTVConfig
   , rtvStatic             = defaultRTVStatic
   , rtvPort               = defaultRTVPort
-  , rtvSlotsPerKESPeriod  = defaultRTVSlotsPerKESPeriod
-  , rtvSlotLength         = defaultRTVSlotLength
   , rtvNodeInfoLife       = defaultRTVNodeInfoLife
   , rtvBlockchainInfoLife = defaultRTVBlockchainInfoLife
   , rtvResourcesInfoLife  = defaultRTVResourcesInfoLife
@@ -69,12 +61,6 @@ defaultRTVStatic = "static"
 
 defaultRTVPort :: Int
 defaultRTVPort = 8024
-
-defaultRTVSlotsPerKESPeriod :: Int
-defaultRTVSlotsPerKESPeriod = 129600 -- Taken from the Mainnet genesis.
-
-defaultRTVSlotLength :: Int
-defaultRTVSlotLength = 1 -- Taken from the Mainnet genesis.
 
 defaultRTVNodeInfoLife
   , defaultRTVBlockchainInfoLife
@@ -106,16 +92,6 @@ parseRTViewParams =
           "The port number"
           "PORT"
           defaultRTVPort
-    <*> parseInt
-          "slots-per-kes"
-          "The number of slots in KES period"
-          "NUM"
-          defaultRTVSlotsPerKESPeriod
-    <*> parseInt
-          "slot-length"
-          "Slot length, in seconds"
-          "NUM"
-          defaultRTVSlotLength
     <*> parseDiffTime
           "node-info-life"
           "Lifetime of node info"

--- a/src/Cardano/RTView/Config.hs
+++ b/src/Cardano/RTView/Config.hs
@@ -42,7 +42,6 @@ import           Cardano.BM.Data.Output (ScribeDefinition (..), ScribeFormat (..
 import           Cardano.BM.Data.Severity (Severity (..))
 
 import           Cardano.RTView.CLI (RTViewParams (..), defaultRTViewParams, defaultRTVPort,
-                                     defaultRTVSlotLength, defaultRTVSlotsPerKESPeriod,
                                      defaultRTVStatic)
 
 -- | There are few possible ways how we can prepare RTView configuration:
@@ -206,18 +205,6 @@ startDialogToPrepareConfig = do
 
   colorize Green BoldIntensity $ do
     TIO.putStrLn ""
-    TIO.putStr $ "Indicate the number of slots in a KES period (default is "
-                 <> showt defaultRTVSlotsPerKESPeriod <> "): "
-  slotsPerKESPeriod <- askAboutSlotsPerKESPeriod
-
-  colorize Green BoldIntensity $ do
-    TIO.putStrLn ""
-    TIO.putStr $ "Indicate the length of slot, in seconds (default is "
-                 <> showt defaultRTVSlotLength <> "): "
-  slotLength <- askAboutSlotLength
-
-  colorize Green BoldIntensity $ do
-    TIO.putStrLn ""
     TIO.putStr $ "Indicate the directory with static content for the web server (default is \""
                  <> T.pack defaultRTVStatic <> "\"): "
   staticDir <- askAboutStaticDir
@@ -246,8 +233,6 @@ startDialogToPrepareConfig = do
   CM.setAcceptAt config (Just remoteAddrsNamed)
 
   let params = defaultRTViewParams { rtvPort = port
-                                   , rtvSlotsPerKESPeriod = slotsPerKESPeriod
-                                   , rtvSlotLength = slotLength
                                    , rtvStatic = staticDir
                                    }
   -- Now show to the user the changes that should be done in node's configuration file.
@@ -459,50 +444,6 @@ askAboutRTViewMachineHost = do
     else do
       TIO.putStrLn $ "Ok, it is assumed that RTView will be launched on the host \"" <> host <> "\"."
       return $ T.unpack host
-
-askAboutSlotsPerKESPeriod :: IO Int
-askAboutSlotsPerKESPeriod = do
-  periodRaw <- TIO.getLine
-  period <-
-    if T.null periodRaw
-      then do
-        TIO.putStrLn $ "Ok, default value " <> showt defaultRTVSlotsPerKESPeriod <> " will be used."
-        return defaultRTVSlotsPerKESPeriod
-      else case readMaybe (T.unpack periodRaw) of
-             Just (n :: Int) -> return n
-             Nothing -> do
-               colorize Red NormalIntensity $
-                 TIO.putStr "It's not a number, please input the number instead: "
-               askAboutSlotsPerKESPeriod
-  if period < 0
-    then do
-      colorize Red NormalIntensity $
-        TIO.putStr "Please choose the positive number."
-      askAboutSlotsPerKESPeriod
-    else
-      return period
-
-askAboutSlotLength :: IO Int
-askAboutSlotLength = do
-  slotLengthRaw <- TIO.getLine
-  slotLength <-
-    if T.null slotLengthRaw
-      then do
-        TIO.putStrLn $ "Ok, default value " <> showt defaultRTVSlotLength <> " will be used."
-        return defaultRTVSlotLength
-      else case readMaybe (T.unpack slotLengthRaw) of
-             Just (n :: Int) -> return n
-             Nothing -> do
-               colorize Red NormalIntensity $
-                 TIO.putStr "It's not a number, please input the number instead: "
-               askAboutSlotLength
-  if slotLength < 0
-    then do
-      colorize Red NormalIntensity $
-        TIO.putStr "Please choose the positive number."
-      askAboutSlotLength
-    else
-      return slotLength
 
 askAboutStaticDir :: IO FilePath
 askAboutStaticDir = do

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -45,6 +45,7 @@ data ElementName
   | ElNodeCommitHref
   | ElActiveNode
   | ElUptime
+  | ElSystemStartTime
   | ElEpoch
   | ElSlot
   | ElBlocksNumber

--- a/src/Cardano/RTView/GUI/Markup/Grid.hs
+++ b/src/Cardano/RTView/GUI/Markup/Grid.hs
@@ -67,6 +67,7 @@ metricLabel ElMemoryUsageChart      = ("Memory usage", "Memory used by the node,
 metricLabel ElCPUUsageChart         = ("CPU usage", "CPU used by the node, in percents")
 metricLabel ElDiskUsageChart        = ("Disk usage", "Node's disk operations, both READ and WRITE")
 metricLabel ElNetworkUsageChart     = ("Network usage", "Node's network operations, both IN and OUT")
+metricLabel ElSystemStartTime       = ("System start time", "The time when this blockchain has started")
 metricLabel ElEpoch                 = ("Epoch", "Number of current epoch")
 metricLabel ElSlot                  = ("Slot in epoch", "Number of the current slot in this epoch")
 metricLabel ElChainDensity          = ("Chain density", "Chain density, in percents")
@@ -102,6 +103,7 @@ allMetricsNames =
   , ElCPUUsageChart
   , ElDiskUsageChart
   , ElNetworkUsageChart
+  , ElSystemStartTime
   , ElEpoch
   , ElSlot
   , ElBlocksNumber
@@ -186,6 +188,7 @@ mkNodeElements nameOfNode = do
                  #. [GridNetworkUsageChart]
                  #+ []
 
+  elSystemStartTime    <- string "00:00:00"
   elEpoch              <- string "0"
   elSlot               <- string "0"
   elBlocksNumber       <- string "0"
@@ -220,6 +223,7 @@ mkNodeElements nameOfNode = do
       , (ElCPUUsageChart,         elCPUUsageChart)
       , (ElDiskUsageChart,        elDiskUsageChart)
       , (ElNetworkUsageChart,     elNetworkUsageChart)
+      , (ElSystemStartTime,       elSystemStartTime)
       , (ElEpoch,                 elEpoch)
       , (ElSlot,                  elSlot)
       , (ElBlocksNumber,          elBlocksNumber)

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -51,6 +51,7 @@ mkNodePane nameOfNode = do
   elNodePlatform              <- string ""
   elActiveNode                <- string "-"
   elUptime                    <- string "00:00:00"
+  elSystemStartTime           <- string "00:00:00"
   elEpoch                     <- string "0"
   elSlot                      <- string "0"
   elBlocksNumber              <- string "0"
@@ -220,7 +221,10 @@ mkNodePane nameOfNode = do
   blockchainTabContent
     <- UI.div #. [TabContainer, W3Row] # hideIt #+
          [ UI.div #. [W3Half] #+
-             [ UI.div #+ [string "Epoch / Slot in epoch"
+             [ UI.div #+ [string "System start time"
+                          # set UI.title__ "The time when this blockchain has started"]
+             , vSpacer NodeInfoVSpacer
+             , UI.div #+ [string "Epoch / Slot in epoch"
                           # set UI.title__ "Number of current epoch / number of the current slot in this epoch"]
              , UI.div #+ [string "Blocks number"
                           # set UI.title__ "Total number of blocks in this blockchain"]
@@ -240,6 +244,9 @@ mkNodePane nameOfNode = do
              ]
          , UI.div #. [W3Half, NodeInfoValues] #+
              [ UI.div #+
+                 [element elSystemStartTime]
+             , vSpacer NodeInfoVSpacer
+             , UI.div #+
                  [ element elEpoch
                  , string " / "
                  , element elSlot
@@ -481,6 +488,7 @@ mkNodePane nameOfNode = do
           , (ElNodeCommitHref,          elNodeCommitHref)
           , (ElActiveNode,              elActiveNode)
           , (ElUptime,                  elUptime)
+          , (ElSystemStartTime,         elSystemStartTime)
           , (ElEpoch,                   elEpoch)
           , (ElSlot,                    elSlot)
           , (ElBlocksNumber,            elBlocksNumber)

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -168,7 +168,9 @@ data RTSMetrics = RTSMetrics
   } deriving (Generic, NFData)
 
 data BlockchainMetrics = BlockchainMetrics
-  { epoch                  :: !Integer
+  { systemStartTime        :: !UTCTime
+  , systemStartTimeChanged :: !Bool
+  , epoch                  :: !Integer
   , epochChanged           :: !Bool
   , epochLastUpdate        :: !Word64
   , slot                   :: !Integer
@@ -199,17 +201,19 @@ data KESMetrics = KESMetrics
   } deriving (Generic, NFData)
 
 data NodeMetrics = NodeMetrics
-  { nodeProtocol        :: !Text
-  , nodeProtocolChanged :: !Bool
-  , nodeVersion         :: !Text
-  , nodeVersionChanged  :: !Bool
-  , nodeCommit          :: !Text
-  , nodeCommitChanged   :: !Bool
-  , nodeShortCommit     :: !Text
-  , nodePlatform        :: !Text
-  , nodePlatformChanged :: !Bool
-  , upTime              :: !Word64
-  , upTimeLastUpdate    :: !Word64
+  { nodeProtocol         :: !Text
+  , nodeProtocolChanged  :: !Bool
+  , nodeVersion          :: !Text
+  , nodeVersionChanged   :: !Bool
+  , nodeCommit           :: !Text
+  , nodeCommitChanged    :: !Bool
+  , nodeShortCommit      :: !Text
+  , nodePlatform         :: !Text
+  , nodePlatformChanged  :: !Bool
+  , nodeStartTime        :: !UTCTime
+  , nodeStartTimeChanged :: !Bool
+  , upTime               :: !Word64
+  , upTimeLastUpdate     :: !Word64
   } deriving (Generic, NFData)
 
 data ErrorsMetrics = ErrorsMetrics
@@ -334,7 +338,9 @@ defaultNodeState = NodeState
         }
   , blockchainMetrics =
       BlockchainMetrics
-        { epoch                  = 0
+        { systemStartTime        = UTCTime (ModifiedJulianDay 0) 0
+        , systemStartTimeChanged = True
+        , epoch                  = 0
         , epochChanged           = True
         , epochLastUpdate        = 0
         , slot                   = 0
@@ -365,17 +371,19 @@ defaultNodeState = NodeState
         }
   , nodeMetrics =
       NodeMetrics
-        { nodeProtocol        = "-"
-        , nodeProtocolChanged = True
-        , nodeVersion         = "-"
-        , nodeVersionChanged  = True
-        , nodeCommit          = "-"
-        , nodeCommitChanged   = True
-        , nodeShortCommit     = "-"
-        , nodePlatform        = "-"
-        , nodePlatformChanged = True
-        , upTime              = 0
-        , upTimeLastUpdate    = 0
+        { nodeProtocol         = "-"
+        , nodeProtocolChanged  = True
+        , nodeVersion          = "-"
+        , nodeVersionChanged   = True
+        , nodeCommit           = "-"
+        , nodeCommitChanged    = True
+        , nodeShortCommit      = "-"
+        , nodePlatform         = "-"
+        , nodePlatformChanged  = True
+        , nodeStartTime        = UTCTime (ModifiedJulianDay 0) 0
+        , nodeStartTimeChanged = True
+        , upTime               = 0
+        , upTimeLastUpdate     = 0
         }
   , nodeErrors =
       ErrorsMetrics


### PR DESCRIPTION
Now RTView receives `nodeBasicInfo` metrics (actual for the node `1.22.1`). Some data (such as `slotLength`, `epochLength`) will be handled later (corresponding tasks are already opened).