### PR TITLE
CAD-2199: STM instead of MVar for nodes state

### DIFF
--- a/cardano-rt-view.cabal
+++ b/cardano-rt-view.cabal
@@ -51,7 +51,6 @@ library
                      , lobemo-backend-trace-acceptor
                      , optparse-applicative
                      , stm
-                     , strict-concurrency
                      , text
                      , threepenny-gui
                      , time


### PR DESCRIPTION
Currently, RTView uses MVar to store the internal state of nodes. Instead, STM should be used:

1. Less dependencies: RTView already uses `stm` package, so if we remove `MVar`, the package strict-concurrency will be removed from dependencies.
2. Atomic writing: now two threads will be writing to this state, so it should use atomic modify.