### PR TITLE
CAD-2204: JSON instead of YAML for internal config.

### DIFF
--- a/cardano-rt-view.cabal
+++ b/cardano-rt-view.cabal
@@ -54,7 +54,6 @@ library
                      , text
                      , threepenny-gui
                      , time
-                     , yaml
 
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings

--- a/src/Cardano/RTView.hs
+++ b/src/Cardano/RTView.hs
@@ -28,7 +28,6 @@ import           Cardano.RTView.WebServer (launchWebServer)
 runCardanoRTView :: RTViewParams -> IO ()
 runCardanoRTView params' = do
   TIO.putStrLn "RTView: real-time watching for Cardano nodes"
-  TIO.putStrLn ""
 
   (config, params, acceptors) <- prepareConfigAndParams params'
 

--- a/src/Cardano/RTView/CLI.hs
+++ b/src/Cardano/RTView/CLI.hs
@@ -14,8 +14,8 @@ module Cardano.RTView.CLI
     , parseRTViewParams
     ) where
 
+import           Data.Aeson (FromJSON (..), ToJSON, (.:), withObject)
 import           Data.Word (Word64)
-import           Data.Yaml (FromJSON (..), ToJSON, (.:), withObject)
 import           GHC.Generics (Generic)
 
 import           Options.Applicative (HasCompleter, HasMetavar, HasName, HasValue, Mod, Parser,


### PR DESCRIPTION
Now it's only JSON format for internal configuration file of RTView. As a result, heavy package `yaml` was removed from dependencies.