### PR TITLE
CAD-2206: sockets connection by default.

### DIFF
--- a/doc/getting-started/install.md
+++ b/doc/getting-started/install.md
@@ -43,9 +43,7 @@ please go to `Settings` -> `Language Settings` -> `Administrative language setti
 After you run an executable `cardano-rt-view`, an interactive dialog will be started:
 
 ```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- RTView: real-time watching for Cardano nodes
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+RTView: real-time watching for Cardano nodes
 
 Let's configure RTView...
 ```
@@ -77,19 +75,16 @@ Please input the port RTView will use to display the web-page. For example, if y
 The next question is:
 
 ```
-Indicate how your nodes should be connected with RTView (pipes <P> or networking sockets <S>):
+Indicate how your nodes should be connected with RTView: networking sockets <S> or named pipes <P>."
+Default way is sockets, so if you are not sure - choose <S>:
 ```
 
-Please choose the way how the nodes should be connected to RTView. If you selected `P`, you will be asked about the directory when pipes will be created:
+Please choose the way how the nodes should be connected to RTView.
+
+If you chose `S`, you will be asked about the base port:
 
 ```
-Ok, pipes will be used. Indicate the directory for them, default is "/run/user/1000/rt-view-pipes":
-```
-
-But if you chose `S`, you will be asked about the base port:
-
-```
-Ok, sockets will be used. Indicate the port base to listen for connections (1024 - 65535, default is 3000):
+Ok, sockets will be used. Indicate the base port to listen for connections (1024 - 65535, default is 3000):
 ```
 
 The base port will be used for the first node that forwards its metrics to RTView. For example, if you will launch three `cardano-node` processes (`node-1`, `node-2`, and `node-3`) that will forward their metrics using network sockets, this is how they will be connected to RTView:
@@ -97,6 +92,12 @@ The base port will be used for the first node that forwards its metrics to RTVie
 1. `node-1` -> `0.0.0.0:3000`
 1. `node-2` -> `0.0.0.0:3001`
 1. `node-3` -> `0.0.0.0:3002`
+
+Bit if you selected `P`, you will be asked about the directory when pipes will be created:
+
+```
+Ok, pipes will be used. Indicate the directory for them, default is "/run/user/1000/rt-view-pipes":
+```
 
 The next question is:
 

--- a/src/Cardano/RTView/Config.hs
+++ b/src/Cardano/RTView/Config.hs
@@ -182,17 +182,11 @@ startDialogToPrepareConfig = do
 
   colorize Green BoldIntensity $ do
     TIO.putStrLn ""
-    TIO.putStr "Indicate how your nodes should be connected with RTView (pipes <P> or networking sockets <S>): "
+    TIO.putStr "Indicate how your nodes should be connected with RTView: networking sockets <S> or named pipes <P>."
+    TIO.putStr "\nDefault way is sockets, so if you are not sure - choose <S>: "
   (remoteAddrs, rtViewMachineHost) <- askAboutPipesAndSockets >>= \case
-    Pipe -> do
-      defDir <- defaultPipesDir
-      TIO.putStr $ "Ok, pipes will be used. Indicate the directory for them (default is \""
-                   <> T.pack defDir <> "\"): "
-      hFlush stdout
-      addrs <- askAboutLocationForPipes nodesNumber
-      return (addrs, defaultRTVHost)
     Socket -> do
-      TIO.putStr $ "Ok, sockets will be used. Indicate the port base to listen for connections ("
+      TIO.putStr $ "Ok, sockets will be used. Indicate the base port to listen for connections ("
                    <> showt minimumPort <> " - " <> showt maximumPort <> ", default is "
                    <> showt defaultFirstPortForSockets <> "): "
       hFlush stdout
@@ -202,6 +196,13 @@ startDialogToPrepareConfig = do
       hFlush stdout
       host <- askAboutRTViewMachineHost
       return (addrsWithDefaultHost, host)
+    Pipe -> do
+      defDir <- defaultPipesDir
+      TIO.putStr $ "Ok, pipes will be used. Indicate the directory for them (default is \""
+                   <> T.pack defDir <> "\"): "
+      hFlush stdout
+      addrs <- askAboutLocationForPipes nodesNumber
+      return (addrs, defaultRTVHost)
 
   colorize Green BoldIntensity $ do
     TIO.putStrLn ""
@@ -366,14 +367,14 @@ data ConnectionWay
 askAboutPipesAndSockets :: IO ConnectionWay
 askAboutPipesAndSockets =
   TIO.getLine >>= \case
-    "P" -> return Pipe
-    "p" -> return Pipe
-    ""  -> return Pipe
     "S" -> return Socket
     "s" -> return Socket
+    ""  -> return Socket
+    "P" -> return Pipe
+    "p" -> return Pipe
     _   -> do
       colorize Red NormalIntensity $
-        TIO.putStr "Sorry? <P>ipes or <S>ockets? "
+        TIO.putStr "Sorry? <S>ockets or <P>ipes? "
       askAboutPipesAndSockets
 
 askAboutLocationForPipes :: Int -> IO [RemoteAddr]


### PR DESCRIPTION
Currently, the default option (during RTView interactive dialog) on how to connect the nodes is pipes. But pipes are for local connection only (both RView and the node are working on the same machine), and most SPOs want to use a distributed way (RTView and the node are working on different machines).

So, now sockets is the default way.