### PR TITLE
CAD-2207: idle node mark was added.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -83,6 +83,18 @@ ownCSS = unpack . TL.toStrict . render $ do
     paddingTopPx      12
     paddingRightPx    18
 
+  cl IdleNode ? do
+    fontWeight        bold
+    color             white
+    marginLeftPx      15
+    paddingTopPx      3
+    paddingBottomPx   1
+    paddingLeftPx     5
+    paddingRightPx    5
+    backgroundColor   red
+    border            solid (px 1) red
+    borderRadiusPx    8
+
   cl NodeNameArea ? do
     fontSizePct       110
     paddingTopPx      10
@@ -291,6 +303,8 @@ ownCSS = unpack . TL.toStrict . render $ do
   widthPct        = width . pct
   minWidthPx      = minWidth . px
   maxWidthPx      = maxWidth . px
+
+  borderRadiusPx v = borderRadius (px v) (px v) (px v) (px v)
 
   progressBarColors bg c = do
     backgroundColor   bg

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -39,11 +39,12 @@ type NodeStateElements = Map ElementName Element
 type NodesStateElements = [(Text, NodeStateElements, [PeerInfoItem])]
 
 data ElementName
-  = ElNodeProtocol
+  = ElNodePane
+  | ElIdleNode
+  | ElNodeProtocol
   | ElNodeVersion
   | ElNodePlatform
   | ElNodeCommitHref
-  | ElActiveNode
   | ElUptime
   | ElSystemStartTime
   | ElEpoch
@@ -141,6 +142,7 @@ data HTMLClass
   | GridNodeNameLabel
   | GridRowCell
   | HSpacer
+  | IdleNode
   | InfoMark
   | InfoMarkImg
   | MetricsArea
@@ -234,6 +236,7 @@ instance Show HTMLClass where
   show GridNodeNameLabel      = "GridNodeNameLabel"
   show GridRowCell            = "GridRowCell"
   show HSpacer                = "HSpacer"
+  show IdleNode               = "IdleNode"
   show InfoMark               = "InfoMark"
   show InfoMarkImg            = "InfoMarkImg"
   show MetricsArea            = "MetricsArea"

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -46,10 +46,11 @@ mkNodePane nameOfNode = do
   -- Create |Element|s containing node state (info, metrics).
   -- These elements will be part of the complete page,
   -- later they will be updated by acceptor thread.
+  elIdleNode <- string "Idle" #. [IdleNode] # hideIt
+
   elNodeProtocol              <- string ""
   elNodeVersion               <- string ""
   elNodePlatform              <- string ""
-  elActiveNode                <- string "-"
   elUptime                    <- string "00:00:00"
   elSystemStartTime           <- string "00:00:00"
   elEpoch                     <- string "0"
@@ -450,11 +451,12 @@ mkNodePane nameOfNode = do
   registerClicksOnTabs tabs
 
   -- Make a widget for one node.
-  nodeWidget <-
+  nodePane <-
     UI.div #. [W3Container, W3Margin, W3Border, NodeContainer] #+
       [ UI.div #. [NodeNameArea] #+
           [ string "Name: "
-          , element elActiveNode #. [NodeName]
+          , string (T.unpack nameOfNode) #. [NodeName]
+          , element elIdleNode
           ]
       , UI.div #. [W3Bar, NodeBar] #+
           [ element nodeTab
@@ -482,11 +484,12 @@ mkNodePane nameOfNode = do
   -- Return these elements, they will be updated by another thread later.
   let nodeStateElems =
         Map.fromList
-          [ (ElNodeProtocol,            elNodeProtocol)
+          [ (ElNodePane,                nodePane)
+          , (ElIdleNode,                elIdleNode)
+          , (ElNodeProtocol,            elNodeProtocol)
           , (ElNodeVersion,             elNodeVersion)
           , (ElNodePlatform,            elNodePlatform)
           , (ElNodeCommitHref,          elNodeCommitHref)
-          , (ElActiveNode,              elActiveNode)
           , (ElUptime,                  elUptime)
           , (ElSystemStartTime,         elSystemStartTime)
           , (ElEpoch,                   elEpoch)
@@ -532,7 +535,7 @@ mkNodePane nameOfNode = do
           , (ElRTSMemoryProgressBox,    elRTSMemoryProgressBox)
           ]
 
-  return (nodeWidget, nodeStateElems, peerInfoItems)
+  return (nodePane, nodeStateElems, peerInfoItems)
 
 ---
 


### PR DESCRIPTION
If particular node is disconnected from RTView (or wasn't connected at all), it is displayed now using `Idle` tag. 

Use-case: user's AWS instance with running node crashed/stopped by some reason, and RTView, in 2 minutes, will show it to the user.