### PR TITLE
CAD-2208: check and show supported versions of cardano node.

### DIFF
--- a/app/cardano-rt-view.hs
+++ b/app/cardano-rt-view.hs
@@ -5,6 +5,7 @@ import           System.IO (hSetEncoding, stdout, stderr, utf8)
 import           System.Win32.Console (setConsoleCP)
 #endif
 
+import           Data.Text (unpack)
 import           Data.Version (showVersion)
 import           Options.Applicative (ParserInfo, (<**>), customExecParser, fullDesc, header,
                                       help, helper, info, infoOption, long, prefs, short,
@@ -12,6 +13,7 @@ import           Options.Applicative (ParserInfo, (<**>), customExecParser, full
 
 import           Cardano.RTView (runCardanoRTView)
 import           Cardano.RTView.CLI (RTViewParams, parseRTViewParams)
+import           Cardano.RTView.SupportedNodes (showSupportedNodesVersions)
 import           Paths_cardano_rt_view (version)
 
 main :: IO ()
@@ -28,10 +30,14 @@ main = do
  where
   rtViewInfo :: ParserInfo RTViewParams
   rtViewInfo = info
-    (parseRTViewParams <**> helper <**> versionOption)
+    (parseRTViewParams <**> helper <**> versionOption <**> supportedNodesOption)
     (fullDesc <> header "cardano-rt-view - real-time view for cardano node.")
   versionOption = infoOption
     (showVersion version)
     (long "version" <>
      short 'v' <>
      help "Show version")
+  supportedNodesOption = infoOption
+    ("Supported versions of Cardano node: " <> unpack showSupportedNodesVersions)
+    (long "supported-nodes" <>
+     help "Show supported versions of Cardano node")

--- a/cardano-rt-view.cabal
+++ b/cardano-rt-view.cabal
@@ -33,6 +33,8 @@ library
                        Cardano.RTView.NodeState.Types
                        Cardano.RTView.NodeState.Updater
 
+                       Cardano.RTView.SupportedNodes
+
                        Cardano.RTView.WebServer
 
   other-modules:       Paths_cardano_rt_view
@@ -75,6 +77,7 @@ executable cardano-rt-view
   build-depends:       base >=4.12 && <5
                      , cardano-rt-view
                      , optparse-applicative
+                     , text
   if os(windows)
     build-depends:     Win32
 

--- a/src/Cardano/RTView/Config.hs
+++ b/src/Cardano/RTView/Config.hs
@@ -43,6 +43,7 @@ import           Cardano.BM.Data.Severity (Severity (..))
 
 import           Cardano.RTView.CLI (RTViewParams (..), defaultRTViewParams, defaultRTVPort,
                                      defaultRTVStatic)
+import           Cardano.RTView.SupportedNodes (showSupportedNodesVersions)
 
 -- | There are few possible ways how we can prepare RTView configuration:
 --   1. By running interactive dialog with the user. If `--config` CLI-option
@@ -149,13 +150,19 @@ askAboutPrevConfig savedConfig savedParams =
 
 startDialogToPrepareConfig :: IO (Configuration, RTViewParams)
 startDialogToPrepareConfig = do
-  colorize Magenta BoldIntensity $ do
-    TIO.putStrLn ""
-    TIO.putStrLn "Let's configure RTView..."
+  colorize Magenta BoldIntensity $
+    TIO.putStrLn "\nLet's configure RTView..."
 
-  colorize Green BoldIntensity $ do
-    TIO.putStrLn ""
-    TIO.putStr $ "How many nodes will you connect (1 - "
+  colorize Magenta NormalIntensity $
+    TIO.putStr $ "\nPlease note that this version of RTView works with the following versions of Cardano node: "
+
+  colorize Magenta BoldIntensity $ do
+    TIO.putStr showSupportedNodesVersions
+    TIO.putStr "\nPress <Enter> to continue..."
+  void TIO.getLine
+
+  colorize Green BoldIntensity $
+    TIO.putStr $ "\nHow many nodes will you connect (1 - "
                <> showt maximumNode <> ", default is " <> showt defaultNodesNumber <> "): "
   nodesNumber <- askAboutNodesNumber
   let (names :: Text, nodes :: Text, are :: Text, oneAtATime :: Text)

--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -95,6 +95,13 @@ ownCSS = unpack . TL.toStrict . render $ do
     border            solid (px 1) red
     borderRadiusPx    8
 
+  cl UnsupportedVersion ? do
+    color             red
+    fontWeight        bold
+    textDecorationLine  underline
+    textDecorationStyle wavy
+    textDecorationColor red
+
   cl NodeNameArea ? do
     fontSizePct       110
     paddingTopPx      10

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -172,6 +172,7 @@ data HTMLClass
   | TabContainer
   | TopBar
   | TXsProcessed
+  | UnsupportedVersion
   | ValueUnit
   | ValueUnitPercent
   -- Charts
@@ -266,6 +267,7 @@ instance Show HTMLClass where
   show TabContainer           = "TabContainer"
   show TopBar                 = "TopBar"
   show TXsProcessed           = "TXsProcessed"
+  show UnsupportedVersion     = "UnsupportedVersion"
   show ValueUnit              = "ValueUnit"
   show ValueUnitPercent       = "ValueUnitPercent"
   show CPUUsageChart          = "CPUUsageChart"

--- a/src/Cardano/RTView/SupportedNodes.hs
+++ b/src/Cardano/RTView/SupportedNodes.hs
@@ -1,0 +1,17 @@
+module Cardano.RTView.SupportedNodes
+    ( supportedNodesVersions
+    , showSupportedNodesVersions
+    ) where
+
+import           Data.Text (Text, intercalate)
+
+-- | Both RTView and 'cardano-node' are under active development.
+--   Since the things change frequently, RTView maintain the list
+--   of nodes' versions that works with this release of RTView.
+supportedNodesVersions :: [Text]
+supportedNodesVersions =
+  [ "1.22.1"
+  ]
+
+showSupportedNodesVersions :: Text
+showSupportedNodesVersions = intercalate ", " supportedNodesVersions


### PR DESCRIPTION
Now `cardano-rt-view` executable shows the list of supported versions of Cardano node. Moreover, if the connected node has unsupported version - it will be shown with explanation.