### PR TITLE
Internal web-server uses 0.0.0.0 now.

### DIFF
--- a/src/Cardano/RTView/WebServer.hs
+++ b/src/Cardano/RTView/WebServer.hs
@@ -28,6 +28,9 @@ launchWebServer nsTVar params acceptors =
   config = UI.defaultConfig
     { UI.jsStatic = Just $ rtvStatic params
     , UI.jsPort   = Just $ rtvPort params
+    -- By default it listens on 127.0.0.1, but it cannot be accessed
+    -- from another machine, so change it to 0.0.0.0.
+    , UI.jsAddr   = Just "0.0.0.0"
     }
 
 mainPage


### PR DESCRIPTION
According to the documentation, it should be possible to access RTView's page from another machine. It's impossible with default `127.0.0.1` address, so change it to `0.0.0.0`.