### PR TITLE
CAD-2320: fix Node commit href.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -42,6 +42,10 @@ ownCSS = unpack . TL.toStrict . render $ do
   a # visited # hover ? do
     color             "#4b0082"
 
+  cl InactiveHref ? do
+    pointerEvents     none
+    cursor            cursorDefault
+
   cl TopBar ? do
     backgroundColor   "#1b2238"
     color             whitesmoke

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -150,6 +150,7 @@ data HTMLClass
   | GridRowCell
   | HSpacer
   | IdleNode
+  | InactiveHref
   | InfoMark
   | InfoMarkImg
   | MetricsArea
@@ -264,6 +265,7 @@ instance Show HTMLClass where
   show GridRowCell            = "GridRowCell"
   show HSpacer                = "HSpacer"
   show IdleNode               = "IdleNode"
+  show InactiveHref           = "InactiveHref"
   show InfoMark               = "InfoMark"
   show InfoMarkImg            = "InfoMarkImg"
   show MetricsArea            = "MetricsArea"

--- a/src/Cardano/RTView/GUI/Markup/Grid.hs
+++ b/src/Cardano/RTView/GUI/Markup/Grid.hs
@@ -227,9 +227,10 @@ mkNodeElements NodeState {..} nameOfNode elIdleNode acceptors = do
                  #+ []
 
   elNodeCommitHref
-    <- UI.anchor # set UI.href ""
+    <- UI.anchor #. [InactiveHref]
+                 # set UI.href ""
                  # set UI.target "_blank"
-                 # set UI.title__ "Browse cardano-node repository on this commit"
+                 # set UI.title__ ""
                  # set UI.text (showText nodeShortCommit)
 
   return $ HM.fromList

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -145,9 +145,10 @@ mkNodePane nsTVar NodeState {..} nameOfNode acceptors = do
                                  ]
   elRTSMemoryProgressBox    <- UI.div #. [ProgressBarBox] #+ [element elRTSMemoryProgress]
 
-  elNodeCommitHref <- UI.anchor # set UI.href ""
+  elNodeCommitHref <- UI.anchor #. [InactiveHref]
+                                # set UI.href ""
                                 # set UI.target "_blank"
-                                # set UI.title__ "Browse cardano-node repository on this commit"
+                                # set UI.title__ ""
                                 # set UI.text (showText nodeShortCommit)
 
   -- Create content area for each tab.

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -384,8 +384,10 @@ setNodeCommit
 setNodeCommit _ _ _ _ False _ _ = return ()
 setNodeCommit tv nameOfNode commit shortCommit True els elName =
   whenJust (els !? elName) $ \el -> do
-    void $ element el # set UI.href ("https://github.com/input-output-hk/cardano-node/commit/"
+    void $ element el #. []
+                      # set UI.href ("https://github.com/input-output-hk/cardano-node/commit/"
                                      <> unpack commit)
+                      # set UI.title__ "Browse cardano-node repository on this commit"
                       # set text (unpack shortCommit)
     setChangedFlag tv
                    nameOfNode


### PR DESCRIPTION
If the `Node commit` link empty (when RTView runs without connected nodes), then click on it opened the new RTView's page. But now it's unclickable until the node forwards real commit.