### PR TITLE
CAD-2325: add Warnings in Errors tab.

### DIFF
--- a/src/Cardano/RTView/ErrorBuffer.hs
+++ b/src/Cardano/RTView/ErrorBuffer.hs
@@ -62,7 +62,7 @@ instance IsEffectuator ErrorBuffer a where
       case locontent of
         LogValue _ _ -> False
         LogError _   -> True
-        _            -> severity lometa >= Error
+        _            -> severity lometa >= Warning
 
   handleOverflow _ = TIO.hPutStrLn stderr "Notice: overflow in ErrorBuffer, dropping log items!"
 


### PR DESCRIPTION
Currently, only Errors, Alerts, Criticals and Emergencies are displayed in the Errors tab. Warnings should be here as well.