### PR TITLE
CAD-2326: fix Node commit href.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -42,10 +42,6 @@ ownCSS = unpack . TL.toStrict . render $ do
   a # visited # hover ? do
     color             "#4b0082"
 
-  cl InactiveHref ? do
-    pointerEvents     none
-    cursor            cursorDefault
-
   cl TopBar ? do
     backgroundColor   "#1b2238"
     color             whitesmoke

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -150,7 +150,6 @@ data HTMLClass
   | GridRowCell
   | HSpacer
   | IdleNode
-  | InactiveHref
   | InfoMark
   | InfoMarkImg
   | MetricsArea
@@ -265,7 +264,6 @@ instance Show HTMLClass where
   show GridRowCell            = "GridRowCell"
   show HSpacer                = "HSpacer"
   show IdleNode               = "IdleNode"
-  show InactiveHref           = "InactiveHref"
   show InfoMark               = "InfoMark"
   show InfoMarkImg            = "InfoMarkImg"
   show MetricsArea            = "MetricsArea"

--- a/src/Cardano/RTView/GUI/Markup/Grid.hs
+++ b/src/Cardano/RTView/GUI/Markup/Grid.hs
@@ -227,11 +227,15 @@ mkNodeElements NodeState {..} nameOfNode elIdleNode acceptors = do
                  #+ []
 
   elNodeCommitHref
-    <- UI.anchor #. [InactiveHref]
-                 # set UI.href ""
-                 # set UI.target "_blank"
-                 # set UI.title__ ""
-                 # set UI.text (showText nodeShortCommit)
+    <- if T.null nodeShortCommit
+         then UI.span #+ [string none] -- No real commit was received from the node yet.
+         else UI.span #+
+                [ UI.anchor # set UI.href ("https://github.com/input-output-hk/cardano-node/commit/"
+                                       <> T.unpack nodeCommit)
+                            # set UI.target "_blank"
+                            # set UI.title__ "Browse cardano-node repository on this commit"
+                            # set UI.text (showText nodeShortCommit)
+                ]
 
   return $ HM.fromList
     [ (ElIdleNode,              elIdleNode)

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -119,6 +119,17 @@ mkNodePane nsTVar NodeState {..} nameOfNode acceptors = do
   elRTSGcNum                  <- string $ showInteger rtsGcNum
   elRTSGcMajorNum             <- string $ showInteger rtsGcMajorNum
 
+  elNodeCommitHref
+    <- if T.null nodeShortCommit
+         then UI.span #+ [string none] -- No real commit was received from the node yet.
+         else UI.span #+
+                [ UI.anchor # set UI.href ("https://github.com/input-output-hk/cardano-node/commit/"
+                                       <> T.unpack nodeCommit)
+                            # set UI.target "_blank"
+                            # set UI.title__ "Browse cardano-node repository on this commit"
+                            # set UI.text (showText nodeShortCommit)
+                ]
+
   -- Progress bars.
   elMempoolBytesProgress    <- UI.div #. [ProgressBar] #+
                                  [ UI.span #. [HSpacer] #+ []
@@ -144,13 +155,7 @@ mkNodePane nsTVar NodeState {..} nameOfNode acceptors = do
                                  , string "MB" #. [BarValueUnit]
                                  ]
   elRTSMemoryProgressBox    <- UI.div #. [ProgressBarBox] #+ [element elRTSMemoryProgress]
-
-  elNodeCommitHref <- UI.anchor #. [InactiveHref]
-                                # set UI.href ""
-                                # set UI.target "_blank"
-                                # set UI.title__ ""
-                                # set UI.text (showText nodeShortCommit)
-
+ 
   -- Create content area for each tab.
   nodeTabContent
     <- UI.div #. [TabContainer, W3Row] # showIt #+

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -384,11 +384,13 @@ setNodeCommit
 setNodeCommit _ _ _ _ False _ _ = return ()
 setNodeCommit tv nameOfNode commit shortCommit True els elName =
   whenJust (els !? elName) $ \el -> do
-    void $ element el #. []
-                      # set UI.href ("https://github.com/input-output-hk/cardano-node/commit/"
-                                     <> unpack commit)
-                      # set UI.title__ "Browse cardano-node repository on this commit"
-                      # set text (unpack shortCommit)
+    void $ element el # set children []
+    void $ element el #+ [ UI.anchor # set UI.href ("https://github.com/input-output-hk/cardano-node/commit/"
+                                       <> unpack commit)
+                                     # set UI.target "_blank"
+                                     # set UI.title__ "Browse cardano-node repository on this commit"
+                                     # set UI.text (showText shortCommit)
+                         ]
     setChangedFlag tv
                    nameOfNode
                    (\ns -> ns { nodeMetrics = (nodeMetrics ns) { nodeCommitChanged = False } })


### PR DESCRIPTION
Previously, until the node sent the real commit, Node commit is empty link, clicking by it opens the same RTView page. Now it's fixed:

1. When the commit wasn't received - it's not a link at all.
2. After the commit is received - it will be turned to the link.