### PR TITLE
CAD-2315: update DOM-elems during changing view mode

### DIFF
--- a/src/Cardano/RTView/GUI/Markup/PageBody.hs
+++ b/src/Cardano/RTView/GUI/Markup/PageBody.hs
@@ -132,11 +132,71 @@ mkPageBody nsTVar window acceptors = do
 
 forceChangingAllElements :: TVar NodesState -> UI ()
 forceChangingAllElements nsTVar =
-  liftIO . atomically $ modifyTVar' nsTVar $ \currentNS ->
-    let updatedNS = map (\(nm, ns) -> (nm, setAllChangedFlags ns)) $ HM.toList currentNS
-    in HM.fromList updatedNS
+  liftIO . atomically $ modifyTVar' nsTVar $
+    HM.fromList . map (\(nm, ns) -> (nm, setAllChangedFlags ns)) . HM.toList
  where
-   setAllChangedFlags ns = ns
+  setAllChangedFlags ns =
+    ns { peersMetrics =
+           (peersMetrics ns)
+             { peersInfoChanged = True
+             }
+       , nodeMetrics =
+           (nodeMetrics ns)
+             { nodeProtocolChanged  = True
+             , nodeVersionChanged   = True
+             , nodeCommitChanged    = True
+             , nodePlatformChanged  = True
+             , nodeStartTimeChanged = True
+             , nodeEndpointChanged  = True
+             }
+       , mempoolMetrics =
+           (mempoolMetrics ns)
+             { mempoolTxsNumberChanged    = True
+             , mempoolTxsPercentChanged   = True
+             , mempoolBytesChanged        = True
+             , mempoolBytesPercentChanged = True
+             , mempoolMaxTxsChanged       = True
+             , mempoolMaxBytesChanged     = True
+             , txsProcessedChanged        = True
+             }
+       , forgeMetrics =
+           (forgeMetrics ns)
+             { nodeIsLeaderNumChanged    = True
+             , slotsMissedNumberChanged  = True
+             , nodeCannotForgeChanged    = True
+             , blocksForgedNumberChanged = True
+             }
+       , rtsMetrics =
+           (rtsMetrics ns)
+             { rtsMemoryAllocatedChanged   = True
+             , rtsMemoryUsedChanged        = True
+             , rtsMemoryUsedPercentChanged = True
+             , rtsGcCpuChanged             = True
+             , rtsGcElapsedChanged         = True
+             , rtsGcNumChanged             = True
+             , rtsGcMajorNumChanged        = True
+             }
+       , blockchainMetrics =
+           (blockchainMetrics ns)
+             { systemStartTimeChanged = True
+             , epochChanged           = True
+             , slotChanged            = True
+             , blocksNumberChanged    = True
+             , chainDensityChanged    = True
+             }
+       , kesMetrics =
+           (kesMetrics ns)
+             { remKESPeriodsChanged         = True
+             , remKESPeriodsInDaysChanged   = True
+             , opCertStartKESPeriodChanged  = True
+             , opCertExpiryKESPeriodChanged = True
+             , currentKESPeriodChanged      = True
+             }
+       , nodeErrors =
+           (nodeErrors ns)
+             { errorsChanged = True
+             }
+       }
 
 topNavigation
   :: [UI Element]

--- a/src/Cardano/RTView/GUI/Markup/PageBody.hs
+++ b/src/Cardano/RTView/GUI/Markup/PageBody.hs
@@ -4,13 +4,15 @@ module Cardano.RTView.GUI.Markup.PageBody
     ( mkPageBody
     ) where
 
-import           Control.Concurrent.STM.TVar (TVar)
+import           Control.Concurrent.STM.TVar (TVar, modifyTVar')
 import           Control.Monad (forM, forM_, void, when)
 import           Control.Monad.Extra (whenJustM)
+import           Control.Monad.STM (atomically)
+import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Graphics.UI.Threepenny as UI
-import           Graphics.UI.Threepenny.Core (Element, UI, element, set, string, (#), (#+))
+import           Graphics.UI.Threepenny.Core (Element, UI, element, liftIO, set, string, (#), (#+))
 
 import           Cardano.BM.Data.Configuration (RemoteAddrNamed (..))
 import qualified Cardano.RTView.GUI.JS.Charts as Chart
@@ -104,9 +106,11 @@ mkPageBody nsTVar window acceptors = do
 
   void $ UI.onEvent (UI.click paneViewButton) $ \_ -> do
     toggleViewMode window "paneMode" bodyRootElem [element paneNodesRootElem] [element gridNodesRootElem]
+    forceChangingAllElements nsTVar
     forElementWithId window (show SelectMetricButton) hideIt
   void $ UI.onEvent (UI.click gridViewButton) $ \_ -> do
     toggleViewMode window "gridMode" bodyRootElem [element gridNodesRootElem] [element paneNodesRootElem]
+    forceChangingAllElements nsTVar
     forElementWithId window (show SelectMetricButton) showIt
     forM_ acceptors $ \(RemoteAddrNamed nameOfNode _) -> do
       UI.runFunction $ UI.ffi Chart.gridMemoryUsageChartJS  (showt GridMemoryUsageChartId  <> nameOfNode)
@@ -125,6 +129,14 @@ mkPageBody nsTVar window acceptors = do
  where
   showt :: Show a => a -> Text
   showt = T.pack . show
+
+forceChangingAllElements :: TVar NodesState -> UI ()
+forceChangingAllElements nsTVar =
+  liftIO . atomically $ modifyTVar' nsTVar $ \currentNS ->
+    let updatedNS = map (\(nm, ns) -> (nm, setAllChangedFlags ns)) $ HM.toList currentNS
+    in HM.fromList updatedNS
+ where
+   setAllChangedFlags ns = ns
 
 topNavigation
   :: [UI Element]

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -16,6 +16,7 @@ import           Data.Maybe (fromJust, isJust)
 import           Data.HashMap.Strict ((!), (!?))
 import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text, pack, strip, unpack)
+import qualified Data.Text as T
 import           Data.Time.Calendar (diffDays)
 import           Data.Time.Clock (NominalDiffTime, UTCTime (..), addUTCTime, getCurrentTime,
                                   diffUTCTime)
@@ -273,7 +274,17 @@ evSetter
 evSetter _ _ _ _ False _ _ = return ()
 evSetter flagSetter tv nameOfNode ev True els elName =
   whenJust (els !? elName) $ \el -> do
-    void $ setElement ev el
+    -- If the value is still default one, don't display it (it's meaningless).
+    let nothing = StringV none
+        ev' =
+          case ev of
+            IntV     _ -> ev
+            IntegerV i -> if i < 0    then nothing else ev
+            Word64V  w -> if w == 0   then nothing else ev
+            DoubleV  d -> if d < 0    then nothing else ev
+            StringV  s -> if null s   then nothing else ev
+            TextV    t -> if T.null t then nothing else ev
+    void $ setElement ev' el
     setChangedFlag tv nameOfNode flagSetter
 
 setElement


### PR DESCRIPTION
Scenario:

- Open RTView web-page (by default it will be in Pane mode).
- DOM-elements will be updated using received metrics.
- Change view mode to Grid view.
- Result: some of the elements won't be updated.
- Expectation: all elements must be updated.

Now it's fixed.