### PR TITLE
CAD-2327: all errors namespaces described.

### DIFF
--- a/doc/getting-started/faq.md
+++ b/doc/getting-started/faq.md
@@ -23,3 +23,7 @@ You can find it [here](https://github.com/input-output-hk/cardano-rt-view/blob/m
 ## «How many nodes can I connect to my RTView process?»
 
 You can connect as many nodes as you want.
+
+## «I know that particular error occurred, but I don't see it in the Errors tab. Why?»
+
+Please make sure you added corresponding tracer name in your node's configuration file. You can find the details [here](https://github.com/input-output-hk/cardano-rt-view/blob/master/doc/getting-started/node-configuration.md#errors-routing).

--- a/doc/getting-started/node-configuration.md
+++ b/doc/getting-started/node-configuration.md
@@ -306,3 +306,66 @@ These are supported tracers:
 | `cardano.node.Forge.metrics`               | `KES` -> `Start KES period`            | `Start KES period`        |
 |                                            | `KES` -> `KES period`                  | `Current KES period`      |
 |                                            | `KES` -> `KES remaining`               | `KES remaining periods`   |
+
+## Errors routing
+
+Node forwards not only the metrics; it forwards possible errors as well. To see a particular error in the `Errors` tab in the `Pane view` mode, you should add corresponding tracers' names in the `mapBackends` section in the node's configuration file.
+
+For example, to see all DNS-related problems, add the following lines in the `mapBackends` section:
+
+```
+"cardano.node.DnsResolver": [
+  "TraceForwarderBK"
+],
+"cardano.node.DnsSubscription": [
+  "TraceForwarderBK"
+]
+```
+
+This is the complete list of tracers' names for all possible errors (actual for Cardano node `1.23.0`):
+
+* `cardano.node.AcceptPolicy`
+* `cardano.node.ChainDB`
+* `cardano.node.DnsResolver`
+* `cardano.node.DnsSubscription`
+* `cardano.node.ErrorPolicy`
+* `cardano.node.Handshake`
+* `cardano.node.IpSubscription`
+* `cardano.node.LocalErrorPolicy`
+* `cardano.node.LocalHandshake`
+* `cardano.node.Mux`
+
+To forward all possible errors to RTView, add the following lines in the `mapBackends` section:
+
+```
+"cardano.node.AcceptPolicy": [
+  "TraceForwarderBK"
+],
+"cardano.node.ChainDB": [
+  "TraceForwarderBK"
+],
+"cardano.node.DnsResolver": [
+  "TraceForwarderBK"
+],
+"cardano.node.DnsSubscription": [
+  "TraceForwarderBK"
+],
+"cardano.node.ErrorPolicy": [
+  "TraceForwarderBK"
+],
+"cardano.node.Handshake": [
+  "TraceForwarderBK"
+],
+"cardano.node.IpSubscription": [
+  "TraceForwarderBK"
+],
+"cardano.node.LocalErrorPolicy": [
+  "TraceForwarderBK"
+],
+"cardano.node.LocalHandshake": [
+  "TraceForwarderBK"
+],
+"cardano.node.Mux": [
+  "TraceForwarderBK"
+]
+```


### PR DESCRIPTION
Since https://github.com/input-output-hk/cardano-node/issues/2119 is still not finished, so we have to describe all tracing namespaces for all possible errors from the node.