### PR TITLE
CAD-2365: remove space leak on Errors.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -167,6 +167,7 @@ ownCSS = unpack . TL.toStrict . render $ do
     widthPx           15
     marginLeftPx      10
     maxHeightPx       19
+    cursor            pointer
 
   cl ErrorsFilterIcon ? do
     widthPx           15
@@ -182,10 +183,12 @@ ownCSS = unpack . TL.toStrict . render $ do
     widthPx           15
     marginLeftPx      10
     maxHeightPx       17
+    cursor            pointer
 
   cl ErrorsRemoveIcon ? do
     widthPx           15
     maxHeightPx       19
+    cursor            pointer
 
   cl ErrorsBadge ? do
     color             white

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -10,6 +10,8 @@ module Cardano.RTView.GUI.Elements
     , ElementValue (..)
     , PeerInfoItem (..)
     , PeerInfoElements (..)
+    , TmpElements (..)
+    , initialTmpElements
     , (#.)
     , (##)
     , dataAttr
@@ -86,7 +88,6 @@ data ElementName
   | ElRTSGcElapsed
   | ElRTSGcNum
   | ElRTSGcMajorNum
-  | ElDownloadErrorsAsCSV
   -- Progress bars.
   | ElMempoolBytesProgress
   | ElMempoolBytesProgressBox
@@ -127,6 +128,16 @@ data PeerInfoElements = PeerInfoElements
   , pieSlotNumber :: !Element
   , pieStatus     :: !Element
   } deriving (Generic, NFData)
+
+-- | The storage for temporary Elements, which should be deleted explicitly.
+--   Please read the documentation for details:
+--   https://hackage.haskell.org/package/threepenny-gui-0.9.0.0/docs/Graphics-UI-Threepenny-Core.html#v:delete
+newtype TmpElements = TmpElements
+  { tmpErrors :: [Element]
+  }
+
+initialTmpElements :: TmpElements
+initialTmpElements = TmpElements []
 
 -- | HTML elements identifiers, we use them in HTML, CSS and JS FFI.
 
@@ -383,6 +394,7 @@ data HTMLId
   | HideAllNodesButton
   | ShowAllNodesButton
   | ViewModeButton
+  | NodeInfoTab
   -- Id parts (the final id will be formed using unique name of node).
   | CPUUsageChartId
   | DiskUsageChartId

--- a/src/Cardano/RTView/GUI/JS/Utils.hs
+++ b/src/Cardano/RTView/GUI/JS/Utils.hs
@@ -1,5 +1,7 @@
 module Cardano.RTView.GUI.JS.Utils
     ( copyTextToClipboard
+    , downloadCSVFile
+    , goToTab
     ) where
 
 copyTextToClipboard :: String
@@ -11,4 +13,21 @@ copyTextToClipboard = concat
   , "document.addEventListener('copy', listener);"
   , "document.execCommand('copy');"
   , "document.removeEventListener('copy', listener);"
+  ]
+
+downloadCSVFile :: String
+downloadCSVFile = concat
+  [ "var element = document.createElement('a');"
+  , "element.setAttribute('href', 'data:application/csv;charset=utf-8,' + %2);"
+  , "element.setAttribute('download', %1);"
+  , "element.style.display = 'none';"
+  , "document.body.appendChild(element);"
+  , "element.click();"
+  , "document.body.removeChild(element);"
+  ]
+
+goToTab :: String
+goToTab = concat
+  [ "var element = document.getElementById(%1);"
+  , "element.click();"
   ]

--- a/src/Cardano/RTView/GUI/Markup/PageBody.hs
+++ b/src/Cardano/RTView/GUI/Markup/PageBody.hs
@@ -18,7 +18,7 @@ import           Cardano.BM.Data.Configuration (RemoteAddrNamed (..))
 import           Cardano.RTView.CLI (RTViewParams (..))
 import qualified Cardano.RTView.GUI.JS.Charts as Chart
 import           Cardano.RTView.GUI.Elements (ElementName (..), HTMLClass (..),
-                                              HTMLId (..), NodesStateElements,
+                                              HTMLId (..), NodesStateElements, TmpElements,
                                               hideIt, showCell, showIt, showRow, (##), (#.))
 import           Cardano.RTView.GUI.Markup.Grid (allMetricsNames, metricLabel, mkNodesGrid)
 import           Cardano.RTView.GUI.Markup.OwnInfo (mkOwnInfo)
@@ -27,12 +27,13 @@ import           Cardano.RTView.NodeState.Types
 
 mkPageBody
   :: TVar NodesState
+  -> TVar TmpElements
   -> RTViewParams
   -> UI.Window
   -> [RemoteAddrNamed]
   -> UI (Element, (NodesStateElements, NodesStateElements))
-mkPageBody nsTVar params window acceptors = do
-  (paneNodesRootElem, paneNodesElems, panesWithNames) <- mkNodesPanes nsTVar acceptors
+mkPageBody nsTVar tmpElsTVar params window acceptors = do
+  (paneNodesRootElem, paneNodesElems, panesWithNames) <- mkNodesPanes nsTVar tmpElsTVar acceptors
   (gridNodesRootElem, gridNodesElems) <- mkNodesGrid nsTVar acceptors
 
   -- Register clickable selector for nodes (to be able to show only one or all of them).

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -209,6 +209,7 @@ data NodeMetrics = NodeMetrics
 data ErrorsMetrics = ErrorsMetrics
   { errors        :: ![NodeError]
   , errorsChanged :: !Bool
+  , errorsRebuild :: !Bool
   } deriving (Generic, NFData)
 
 initialNodesState
@@ -340,6 +341,7 @@ initialNodeState now = NodeState
       ErrorsMetrics
         { errors        = []
         , errorsChanged = True
+        , errorsRebuild = False
         }
   , metricsLastUpdate = now
   }

--- a/src/Cardano/RTView/NodeState/Updater.hs
+++ b/src/Cardano/RTView/NodeState/Updater.hs
@@ -96,8 +96,9 @@ updateNodeErrors ns (LOMeta timeStamp _ _ sev _) aContent = ns { nodeErrors = ne
   newMetrics = currentMetrics
     { errors = newErrors
     , errorsChanged = True -- Every error message changes current list of errors by definition.
+    , errorsRebuild = False -- By default we shouldn't rebuild all the list.
     }
-  newErrors = NodeError timeStamp sev errorMessage visible : currentErrors
+  newErrors = currentErrors ++ [NodeError timeStamp sev errorMessage visible]
   currentMetrics = nodeErrors ns
   currentErrors = errors currentMetrics
   errorMessage =


### PR DESCRIPTION
This PR improves work with Errors tab: now new elements do not rebuild all the list from scratch every time, so there's no more huge space leak.