### PR TITLE
CAD-2364: new metrics, new namespaces.

### DIFF
--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -79,20 +79,13 @@ data ElementName
   | ElMempoolBytesPercent
   | ElMempoolMaxTxs
   | ElMempoolMaxBytes
-  | ElRTSMemoryAllocated
-  | ElRTSMemoryUsed
-  | ElRTSMemoryUsedPercent
-  | ElRTSGcCpu
-  | ElRTSGcElapsed
-  | ElRTSGcNum
   | ElRTSGcMajorNum
+  | ElRTSGcMinorNum
   -- Progress bars.
   | ElMempoolBytesProgress
   | ElMempoolBytesProgressBox
   | ElMempoolTxsProgress
   | ElMempoolTxsProgressBox
-  | ElRTSMemoryProgress
-  | ElRTSMemoryProgressBox
   -- Charts
   | ElMemoryUsageChart
   | ElCPUUsageChart

--- a/src/Cardano/RTView/GUI/JS/Charts.hs
+++ b/src/Cardano/RTView/GUI/JS/Charts.hs
@@ -24,9 +24,15 @@ memoryUsageChartJS = concat
   , "  data: {"
   , "    labels: [],"
   , "    datasets: [{"
-  , "      label: 'Memory usage',"
+  , "      label: 'Memory | kernel',"
   , "      backgroundColor: '#FF8000',"
   , "      borderColor: '#FF8000',"
+  , "      data: [],"
+  , "      fill: false"
+  , "    },{"
+  , "      label: 'Memory | RTS',"
+  , "      backgroundColor: '#DC143C',"
+  , "      borderColor: '#DC143C',"
   , "      data: [],"
   , "      fill: false"
   , "    }]"
@@ -57,9 +63,21 @@ cpuUsageChartJS = concat
   , "  data: {"
   , "    labels: [],"
   , "    datasets: [{"
-  , "      label: 'CPU usage',"
+  , "      label: 'CPU | total',"
   , "      backgroundColor: '#FE2E2E',"
   , "      borderColor: '#FE2E2E',"
+  , "      data: [],"
+  , "      fill: false"
+  , "    },{"
+  , "      label: 'CPU | code',"
+  , "      backgroundColor: '#008B8B',"
+  , "      borderColor: '#008B8B',"
+  , "      data: [],"
+  , "      fill: false"
+  , "    },{"
+  , "      label: 'CPU | GC',"
+  , "      backgroundColor: '#8B0000',"
+  , "      borderColor: '#8B0000',"
   , "      data: [],"
   , "      fill: false"
   , "    }]"
@@ -163,16 +181,18 @@ networkUsageChartJS = concat
 -- Chart updaters.
 -- Please note that after 900 data points (which are collected in every 30 minutes)
 -- we remove outdated points. It allows to avoid too compressed, narrow charts.
+-- This is a temporary solution, it will be improved in the future releases.
 
 updateMemoryUsageChartJS
   , updateCPUUsageChartJS
   , updateDiskUsageChartJS
   , updateNetworkUsageChartJS :: String
-updateMemoryUsageChartJS  = updateSingleDatasetChartJS
-updateCPUUsageChartJS     = updateSingleDatasetChartJS
+updateMemoryUsageChartJS  = updateDoubleDatasetChartJS
+updateCPUUsageChartJS     = updateThreeDatasetsChartJS
 updateDiskUsageChartJS    = updateDoubleDatasetChartJS
 updateNetworkUsageChartJS = updateDoubleDatasetChartJS
 
+{-
 updateSingleDatasetChartJS :: String
 updateSingleDatasetChartJS = concat
   [ "window.charts.get(%1).data.labels.push(%2);"
@@ -184,6 +204,7 @@ updateSingleDatasetChartJS = concat
   , "window.charts.get(%1).data.datasets[0].data.push(%3);"
   , "window.charts.get(%1).update({duration: 0});"
   ]
+-}
 
 updateDoubleDatasetChartJS :: String
 updateDoubleDatasetChartJS = concat
@@ -196,5 +217,21 @@ updateDoubleDatasetChartJS = concat
   , "}"
   , "window.charts.get(%1).data.datasets[0].data.push(%3);"
   , "window.charts.get(%1).data.datasets[1].data.push(%4);"
+  , "window.charts.get(%1).update({duration: 0});"
+  ]
+
+updateThreeDatasetsChartJS :: String
+updateThreeDatasetsChartJS = concat
+  [ "window.charts.get(%1).data.labels.push(%2);"
+  , "var len = window.charts.get(%1).data.labels.length;"
+  , "if (len == 900) {"
+  , "  window.charts.get(%1).data.datasets[0].data.splice(0, len);"
+  , "  window.charts.get(%1).data.datasets[1].data.splice(0, len);"
+  , "  window.charts.get(%1).data.datasets[2].data.splice(0, len);"
+  , "  window.charts.get(%1).data.labels.splice(0, len);"
+  , "}"
+  , "window.charts.get(%1).data.datasets[0].data.push(%3);"
+  , "window.charts.get(%1).data.datasets[1].data.push(%4);"
+  , "window.charts.get(%1).data.datasets[2].data.push(%5);"
   , "window.charts.get(%1).update({duration: 0});"
   ]

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -149,20 +149,17 @@ data ResourcesMetrics = ResourcesMetrics
   } deriving (Generic, NFData, Show)
 
 data RTSMetrics = RTSMetrics
-  { rtsMemoryAllocated          :: !Double
-  , rtsMemoryAllocatedChanged   :: !Bool
-  , rtsMemoryUsed               :: !Double
-  , rtsMemoryUsedChanged        :: !Bool
-  , rtsMemoryUsedPercent        :: !Double
-  , rtsMemoryUsedPercentChanged :: !Bool
-  , rtsGcCpu                    :: !Double
-  , rtsGcCpuChanged             :: !Bool
-  , rtsGcElapsed                :: !Double
-  , rtsGcElapsedChanged         :: !Bool
-  , rtsGcNum                    :: !Integer
-  , rtsGcNumChanged             :: !Bool
-  , rtsGcMajorNum               :: !Integer
-  , rtsGcMajorNumChanged        :: !Bool
+  { rtsMemoryUsed        :: !Double
+  , rtsGcMajorNum        :: !Integer
+  , rtsGcMajorNumChanged :: !Bool
+  , rtsGcMinorNum        :: !Integer
+  , rtsGcMinorNumChanged :: !Bool
+  , rtsGCPercent         :: !Double
+  , rtsGCLast            :: !Integer
+  , rtsGCNs              :: !Word64
+  , rtsMutPercent        :: !Double
+  , rtsMutLast           :: !Integer
+  , rtsMutNs             :: !Word64
   } deriving (Generic, NFData, Show)
 
 data BlockchainMetrics = BlockchainMetrics
@@ -281,20 +278,17 @@ initialNodeState now = NodeState
         }
   , rtsMetrics =
       RTSMetrics
-        { rtsMemoryAllocated          = -0.1
-        , rtsMemoryAllocatedChanged   = False
-        , rtsMemoryUsed               = -0.1
-        , rtsMemoryUsedChanged        = False
-        , rtsMemoryUsedPercent        = -0.1
-        , rtsMemoryUsedPercentChanged = False
-        , rtsGcCpu                    = -0.1
-        , rtsGcCpuChanged             = False
-        , rtsGcElapsed                = -0.1
-        , rtsGcElapsedChanged         = False
-        , rtsGcNum                    = -1
-        , rtsGcNumChanged             = False
-        , rtsGcMajorNum               = -1
-        , rtsGcMajorNumChanged        = False
+        { rtsMemoryUsed        = 0.1
+        , rtsGcMajorNum        = -1
+        , rtsGcMajorNumChanged = False
+        , rtsGcMinorNum        = -1
+        , rtsGcMinorNumChanged = False
+        , rtsGCPercent         = 0.1
+        , rtsGCLast            = 0
+        , rtsGCNs              = 10000
+        , rtsMutPercent        = 0.1
+        , rtsMutLast           = 0
+        , rtsMutNs             = 10000
         }
   , blockchainMetrics =
       BlockchainMetrics

--- a/src/Cardano/RTView/SupportedNodes.hs
+++ b/src/Cardano/RTView/SupportedNodes.hs
@@ -10,8 +10,8 @@ import           Data.Text (Text, intercalate)
 --   of nodes' versions that works with this release of RTView.
 supportedNodesVersions :: [Text]
 supportedNodesVersions =
-  [ "1.22.1"
-  , "1.23.0"
+  [ "1.24.1"
+  , "1.24.2"
   ]
 
 showSupportedNodesVersions :: Text


### PR DESCRIPTION
1. Metrics were moved to global namespace, because all `LogValue`s have unique names.
2. RTS metrics were changed: 5 metrics = 2 in GC tab, 3 in CPU/Memory charts.