### PR TITLE
CAD-2400: select Panes columns.

### DIFF
--- a/src/Cardano/RTView/GUI/CSS/Style.hs
+++ b/src/Cardano/RTView/GUI/CSS/Style.hs
@@ -239,7 +239,7 @@ ownCSS = unpack . TL.toStrict . render $ do
   cl EmergencyMessageTagNoHelp ? errorTag red        4 5 pointer
 
   cl NodeContainer ? do
-    minHeightPx       500
+    minHeightPx       502
     backgroundColor   "#eeeeee"
 
   cl NodeMenuIcon ? do
@@ -308,17 +308,9 @@ ownCSS = unpack . TL.toStrict . render $ do
   cl NodeMetricsValues ? do
     fontWeight        bold
 
-  cl CPUUsageChart ? do
-    maxHeightPx       360
-
-  cl MemoryUsageChart ? do
-    maxHeightPx       360
-
-  cl DiskUsageChart ? do
-    maxHeightPx       360
-
-  cl NetworkUsageChart ? do
-    maxHeightPx       360
+  cl ChartArea ? do
+    important $
+      widthPct        100
 
   cl SelectNodeCheckArea ? do
     marginTopPx       8
@@ -363,6 +355,7 @@ ownCSS = unpack . TL.toStrict . render $ do
   fontSizePct     = fontSize . pct
 
   heightPx        = height . px
+  -- heightPct       = height . pct
   minHeightPx     = minHeight . px
   maxHeightPx     = maxHeight . px
 

--- a/src/Cardano/RTView/GUI/Elements.hs
+++ b/src/Cardano/RTView/GUI/Elements.hs
@@ -163,6 +163,7 @@ data HTMLClass
   | NodeMenuIcon
   | NodeName
   | NodeNameArea
+  | NodePaneArea
   | PercentsSlashHSpacer
   | ProgressBar
   | ProgressBarBox
@@ -187,10 +188,7 @@ data HTMLClass
   | ValueUnit
   | ValueUnitPercent
   -- Charts
-  | CPUUsageChart
-  | MemoryUsageChart
-  | DiskUsageChart
-  | NetworkUsageChart
+  | ChartArea
   -- Error messages
   | WarningMessage
   | WarningMessageTag
@@ -218,6 +216,7 @@ data HTMLClass
   | W3BorderBottom
   | W3BorderTop
   | W3Button
+  | W3Card2
   | W3Card4
   | W3Check
   | W3Col
@@ -246,7 +245,10 @@ data HTMLClass
   | W3Third
   | W3TwoThird
   | W3Quarter
+  | W3L3
+  | W3L4
   | W3L6
+  | W3L12
   | W3M12
   | W3S12
 
@@ -281,6 +283,7 @@ instance Show HTMLClass where
   show NodeMenuIcon           = "NodeMenuIcon"
   show NodeName               = "NodeName"
   show NodeNameArea           = "NodeNameArea"
+  show NodePaneArea           = "NodePaneArea"
   show PercentsSlashHSpacer   = "PercentsSlashHSpacer"
   show ProgressBar            = "ProgressBar"
   show ProgressBarBox         = "ProgressBarBox"
@@ -304,10 +307,7 @@ instance Show HTMLClass where
   show UnsupportedVersion     = "UnsupportedVersion"
   show ValueUnit              = "ValueUnit"
   show ValueUnitPercent       = "ValueUnitPercent"
-  show CPUUsageChart          = "CPUUsageChart"
-  show MemoryUsageChart       = "MemoryUsageChart"
-  show DiskUsageChart         = "DiskUsageChart"
-  show NetworkUsageChart      = "NetworkUsageChart"
+  show ChartArea              = "ChartArea"
   show WarningMessage         = "WarningMessage"
   show WarningMessageTag      = "WarningMessageTag"
   show WarningMessageTagNoHelp = "WarningMessageTagNoHelp"
@@ -334,6 +334,7 @@ instance Show HTMLClass where
   show W3BorderBottom    = "w3-border-bottom"
   show W3BorderTop       = "w3-border-top"
   show W3Button          = "w3-button"
+  show W3Card2           = "w3-card-2"
   show W3Card4           = "w3-card-4"
   show W3Check           = "w3-check"
   show W3Col             = "w3-col"
@@ -362,7 +363,10 @@ instance Show HTMLClass where
   show W3Third           = "w3-third"
   show W3TwoThird        = "w3-twothird"
   show W3Quarter         = "w3-quarter"
+  show W3L3              = "l3"
+  show W3L4              = "l4"
   show W3L6              = "l6"
+  show W3L12             = "l12"
   show W3M12             = "m12"
   show W3S12             = "s12"
 

--- a/src/Cardano/RTView/GUI/JS/Charts.hs
+++ b/src/Cardano/RTView/GUI/JS/Charts.hs
@@ -10,6 +10,7 @@ module Cardano.RTView.GUI.JS.Charts
     , updateCPUUsageChartJS
     , updateDiskUsageChartJS
     , updateNetworkUsageChartJS
+    , resizeChartJS
     ) where
 
 prepareChartsJS :: String
@@ -38,6 +39,7 @@ memoryUsageChartJS = concat
   , "    }]"
   , "  },"
   , "  options: {"
+  , "    responsive: true,"
   , "    scales: {"
   , "      yAxes: [{"
   , "        display: true,"
@@ -83,6 +85,7 @@ cpuUsageChartJS = concat
   , "    }]"
   , "  },"
   , "  options: {"
+  , "    responsive: true,"
   , "    scales: {"
   , "      yAxes: [{"
   , "        display: true,"
@@ -122,6 +125,7 @@ diskUsageChartJS = concat
   , "    }]"
   , "  },"
   , "  options: {"
+  , "    responsive: true,"
   , "    scales: {"
   , "      yAxes: [{"
   , "        display: true,"
@@ -161,6 +165,7 @@ networkUsageChartJS = concat
   , "    }]"
   , "  },"
   , "  options: {"
+  , "    responsive: true,"
   , "    scales: {"
   , "      yAxes: [{"
   , "        display: true,"
@@ -203,6 +208,7 @@ updateSingleDatasetChartJS = concat
   , "}"
   , "window.charts.get(%1).data.datasets[0].data.push(%3);"
   , "window.charts.get(%1).update({duration: 0});"
+  , "window.charts.get(%1).resize();"
   ]
 -}
 
@@ -218,6 +224,7 @@ updateDoubleDatasetChartJS = concat
   , "window.charts.get(%1).data.datasets[0].data.push(%3);"
   , "window.charts.get(%1).data.datasets[1].data.push(%4);"
   , "window.charts.get(%1).update({duration: 0});"
+  , "window.charts.get(%1).resize();"
   ]
 
 updateThreeDatasetsChartJS :: String
@@ -234,4 +241,9 @@ updateThreeDatasetsChartJS = concat
   , "window.charts.get(%1).data.datasets[1].data.push(%4);"
   , "window.charts.get(%1).data.datasets[2].data.push(%5);"
   , "window.charts.get(%1).update({duration: 0});"
+  , "window.charts.get(%1).resize();"
   ]
+
+-- During changing of panes' size we have to explicitly recise charts.
+resizeChartJS :: String
+resizeChartJS = "window.charts.get(%1).resize();"

--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -50,7 +50,7 @@ mkNodesPanes nsTVar tmpElsTVar acceptors = do
 
   panesAreas
     <- forM nodePanesWithElems $ \(_, pane, _, _) ->
-         return $ UI.div #. [W3Col, W3L6, W3M12, W3S12] #+ [element pane]
+         return $ UI.div #. [W3Col, W3L6, W3M12, W3S12, NodePaneArea] #+ [element pane]
 
   let nodesEls       = [(name, elems, piItems) | (name, _,    elems, piItems) <- nodePanesWithElems]
       panesWithNames = [(name, pane)           | (name, pane, _,     _)       <- nodePanesWithElems]
@@ -348,28 +348,28 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
   resourcesTabMemoryContent
     <- UI.div #. [W3Container, TabContainer] # hideIt #+
          [ UI.canvas ## (show MemoryUsageChartId <> T.unpack nameOfNode)
-                     #. [MemoryUsageChart]
+                     #. [ChartArea]
                      #+ []
          ]
 
   resourcesTabCPUContent
     <- UI.div #. [W3Container, TabContainer] # hideIt #+
          [ UI.canvas ## (show CPUUsageChartId <> T.unpack nameOfNode)
-                     #. [CPUUsageChart]
+                     #. [ChartArea]
                      #+ []
          ]
 
   resourcesTabDiskContent
     <- UI.div #. [W3Container, TabContainer] # hideIt #+
          [ UI.canvas ## (show DiskUsageChartId <> T.unpack nameOfNode)
-                     #. [DiskUsageChart]
+                     #. [ChartArea]
                      #+ []
          ]
 
   resourcesTabNetworkContent
     <- UI.div #. [W3Container, TabContainer] # hideIt #+
          [ UI.canvas ## (show NetworkUsageChartId <> T.unpack nameOfNode)
-                     #. [NetworkUsageChart]
+                     #. [ChartArea]
                      #+ []
          ]
 
@@ -463,7 +463,7 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
                          , UI.div #. [W3DropdownHover, W3Mobile] #+
                              [ element elFilterBySev
                              , UI.img #. [ErrorsFilterDropdownIcon] # set UI.src "/static/images/dropdown-dark.svg"
-                             , UI.div #. [W3DropdownContent, W3BarBlock] #+
+                             , UI.div #. [W3DropdownContent, W3BarBlock, W3Card4] #+
                                  [ element filterWarning
                                  , element filterError
                                  , element filterCritical
@@ -501,7 +501,6 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
 
       anchorButton title iconName =
         UI.anchor #. [W3BarItem, W3Button, W3Mobile]
-                  # set UI.href "#"
                   #+ [ UI.img #. [ResourcesIcon]
                               # set UI.src ("/static/images/" <> iconName)
                      , string title
@@ -598,7 +597,7 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
              [ UI.img #. [NodeMenuIcon] # set UI.src "/static/images/resources.svg"
              , UI.img #. [ResourcesDropdownIcon] # set UI.src "/static/images/dropdown-blue.svg"
              ]
-         , UI.div #. [W3DropdownContent, W3BarBlock] #+
+         , UI.div #. [W3DropdownContent, W3BarBlock, W3Card4] #+
              [ element resourcesTabMemory
              , element resourcesTabCPU
              , element resourcesTabDisk
@@ -617,7 +616,7 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
                       , (mempoolTab,          mempoolTabContent)
                       , (resourcesTabMemory,  resourcesTabMemoryContent)
                       , (resourcesTabCPU,     resourcesTabCPUContent)
-                      -- Temporarily removed (new metrics in iohk-monitoring should be implemented).
+                      -- Temporarily disabled (new metrics in iohk-monitoring should be implemented).
                       -- , (resourcesTabDisk,    resourcesTabDiskContent)
                       -- , (resourcesTabNetwork, resourcesTabNetworkContent)
                       , (errorsTab,           errorsTabContent)
@@ -629,7 +628,7 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
 
   -- Make a widget for one node.
   nodePane <-
-    UI.div #. [W3Container, W3Margin, W3Border, NodeContainer] #+
+    UI.div #. [W3Container, W3Margin, W3Border, W3Card2, NodeContainer] #+
       [ UI.div #. [NodeNameArea] #+
           [ string "Name: "
           , string (T.unpack nameOfNode) #. [NodeName]


### PR DESCRIPTION
Now it's possible to select the number of "nodes columns": 1 node, 2 nodes or 3 nodes per row. It's useful in situations when you want to see charts and/or Errors tab on a wider window. Or, in other cases, if you have big monitor, you can display 3 node panes per row and see a lot of nodes in a more compact way.