### PR TITLE
CAD-2423: Text instead of String in node's state

### DIFF
--- a/cardano-rt-view.cabal
+++ b/cardano-rt-view.cabal
@@ -58,6 +58,7 @@ library
                      , bytestring
                      , clay
                      , cassava
+                     , containers
                      , deepseq
                      , directory
                      , extra

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -359,12 +359,12 @@ updatePeersList tv nameOfNode peersInfo' True peersInfoItems = do
     let item  = peersInfoItems L.!! i
         PeerInfoElements {..} = piItemElems item
     -- Update internal elements of item using actual values.
-    void $ setElement (StringV piEndpoint)   pieEndpoint
-    void $ setElement (StringV piBytesInF)   pieBytesInF
-    void $ setElement (StringV piReqsInF)    pieReqsInF
-    void $ setElement (StringV piBlocksInF)  pieBlocksInF
-    void $ setElement (StringV piSlotNumber) pieSlotNumber
-    void $ setElement (StringV piStatus)     pieStatus
+    void $ setElement (TextV piEndpoint)   pieEndpoint
+    void $ setElement (TextV piBytesInF)   pieBytesInF
+    void $ setElement (TextV piReqsInF)    pieReqsInF
+    void $ setElement (TextV piBlocksInF)  pieBlocksInF
+    void $ setElement (TextV piSlotNumber) pieSlotNumber
+    void $ setElement (TextV piStatus)     pieStatus
     -- Make item visible.
     showElement $ piItem item
   setChangedFlag tv
@@ -472,7 +472,7 @@ justUpdateErrorsListAndTab tmpElsTVar
           ]
       , UI.div #. [W3TwoThird] #+
           [ UI.string aTag #. [aTagClass] # set UI.title__ aTagTitle
-          , UI.string msg  #. [aClass]
+          , UI.string (unpack msg) #. [aClass]
           ]
       ]
 

--- a/src/Cardano/RTView/NodeState/Parsers.hs
+++ b/src/Cardano/RTView/NodeState/Parsers.hs
@@ -7,7 +7,6 @@ module Cardano.RTView.NodeState.Parsers
 import           Data.Aeson (Object, (.:))
 import qualified Data.Aeson as A
 import           Data.Text (Text)
-import qualified Data.Text as T
 
 import           Cardano.RTView.NodeState.Types (PeerInfo (..))
 
@@ -17,12 +16,12 @@ extractPeersInfo peersObj =
     A.Success (ConnectedPeers cPeers) ->
       flip map cPeers $ \p ->
         PeerInfo
-          { piEndpoint   = T.unpack $ peerAddress p
-          , piBytesInF   = T.unpack $ peerBytesInF p
-          , piReqsInF    = T.unpack $ peerReqsInF p
-          , piBlocksInF  = T.unpack $ peerBlocksInF p
-          , piSlotNumber = T.unpack $ peerSlotNo p
-          , piStatus     = T.unpack $ peerStatus p
+          { piEndpoint   = peerAddress p
+          , piBytesInF   = peerBytesInF p
+          , piReqsInF    = peerReqsInF p
+          , piBlocksInF  = peerBlocksInF p
+          , piSlotNumber = peerSlotNo p
+          , piStatus     = peerStatus p
           }
     A.Error _ -> []
  where

--- a/src/Cardano/RTView/NodeState/Types.hs
+++ b/src/Cardano/RTView/NodeState/Types.hs
@@ -56,12 +56,12 @@ import           Cardano.BM.Data.Severity (Severity (..))
 type NodesState = HashMap Text NodeState
 
 data PeerInfo = PeerInfo
-  { piEndpoint   :: !String
-  , piBytesInF   :: !String
-  , piReqsInF    :: !String
-  , piBlocksInF  :: !String
-  , piSlotNumber :: !String
-  , piStatus     :: !String
+  { piEndpoint   :: !Text
+  , piBytesInF   :: !Text
+  , piReqsInF    :: !Text
+  , piBlocksInF  :: !Text
+  , piSlotNumber :: !Text
+  , piStatus     :: !Text
   } deriving (Eq, Generic, NFData, Show)
 
 -- Severity type already has Generic instance.
@@ -70,7 +70,7 @@ instance NFData Severity
 data NodeError = NodeError
   { eTimestamp :: !UTCTime
   , eSeverity  :: !Severity
-  , eMessage   :: !String
+  , eMessage   :: !Text
   , eVisible   :: !Bool
   } deriving (Generic, NFData, Show)
 

--- a/src/Cardano/RTView/NodeState/Updater.hs
+++ b/src/Cardano/RTView/NodeState/Updater.hs
@@ -106,11 +106,11 @@ updateNodeErrors ns (LOMeta timeStamp _ _ sev _) aContent = ns { nodeErrors = ne
   currentErrors = errors currentMetrics
   errorMessage =
     case aContent of
-      LogMessage msg -> show msg
-      LogError eMsg -> T.unpack eMsg
-      LogStructured obj -> show obj
-      LogStructuredText _ txt -> T.unpack txt
-      MonitoringEffect (MonitorAlert msg) -> "Monitor alert: " <> T.unpack msg
+      LogMessage msg -> T.pack (show msg)
+      LogError eMsg -> eMsg
+      LogStructured obj -> T.pack (show obj)
+      LogStructuredText _ txt -> txt
+      MonitoringEffect (MonitorAlert msg) -> "Monitor alert: " <> msg
       MonitoringEffect _ -> ""
       _ -> "UNPARSED_ERROR_MESSAGE"
   visible = True

--- a/src/Cardano/RTView/Notifications/CheckEvents.hs
+++ b/src/Cardano/RTView/Notifications/CheckEvents.hs
@@ -66,7 +66,7 @@ checkErrors ErrorsEvents {..} nodesState =
       _         -> False
 
   mkErrMessage sev msg =
-    "Error occurred: severity '" <> pack (show sev) <> "', message: " <> pack msg
+    "Error occurred: severity '" <> pack (show sev) <> "', message: " <> msg
 
 checkBlockchainErrors
   :: BlockchainEvents


### PR DESCRIPTION
Using strict `Texts` instead of `String` makes code simpler and increases the strictness.