### PR TITLE
CAD-2459: fix empty Errors list.

### DIFF
--- a/src/Cardano/RTView/GUI/Markup/Pane.hs
+++ b/src/Cardano/RTView/GUI/Markup/Pane.hs
@@ -516,6 +516,11 @@ mkNodePane nsTVar tmpElsTVar NodeState {..} nameOfNode acceptors = do
   errorsBadge   <- UI.span #. [W3Badge, ErrorsBadge] # hideIt #+ [string ""]
   errorsTab     <- tabButton "Errors" "bugs.svg" (Just errorsBadge) # set UI.enabled False
 
+  -- If we already have some errors in the node's state - update the list in "Errors" tab right now.
+  let errors' = errors nodeErrors
+      shouldWeRebuild = True
+  justUpdateErrorsListAndTab tmpElsTVar errors' shouldWeRebuild elNodeErrorsList errorsTab errorsBadge
+
   void $ UI.onEvent (UI.click elSortByTime) $ \_ -> do
     UI.get (dataAttr dataSortByTime) elSortByTime >>= \case
       "desc" -> do

--- a/src/Cardano/RTView/GUI/Updater.hs
+++ b/src/Cardano/RTView/GUI/Updater.hs
@@ -416,6 +416,7 @@ justUpdateErrorsListAndTab
   -> Element
   -> Element
   -> UI ()
+justUpdateErrorsListAndTab _ [] _ _ _ _ = return ()
 justUpdateErrorsListAndTab tmpElsTVar
                            nodeErrors'
                            shouldWeRebuild


### PR DESCRIPTION
If the user reloads the page when some errors are already presented in the node's state - the list in `Errors` tab will be updated immediately.